### PR TITLE
Fixed invalid import

### DIFF
--- a/cloudstack/cloudstack.yaml
+++ b/cloudstack/cloudstack.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_0
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/3.1/types.yaml
-    - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-cloudstack-plugin/master/plugin.yaml.template
+    - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-cloudstack-plugin/master/plugin.yaml
     - http://www.getcloudify.org/spec/fabric-plugin/1.1/plugin.yaml
 
 


### PR DESCRIPTION
When run 

cfy local install-plugins -p cloudify-manager-blueprints/cloudstack/cloudstack.yaml

It will fail with the error:
Failed on import - Unable to open import url https://raw.githubusercontent.com/cloudify-cosmo/cloudify-cloudstack-plugin/master/plugin.yaml.template;

I corrected the import.