### PR TITLE
Revert "CFY-5117 now correctly passing external rabbitmq endpoint"

### DIFF
--- a/components/elasticsearch/scripts/create.py
+++ b/components/elasticsearch/scripts/create.py
@@ -220,7 +220,7 @@ def _install_elasticsearch():
 
     _configure_index_rotation()
 
-    # elasticsearch provides a systemd init env. we just enable it.
+    ctx.logger.info('Enabling Elasticsearch Service...')
     utils.systemd.enable('elasticsearch')
 
 

--- a/components/rabbitmq/scripts/create.py
+++ b/components/rabbitmq/scripts/create.py
@@ -95,9 +95,11 @@ def _install_rabbitmq():
 
     utils.logrotate('rabbitmq')
 
+    # Creating rabbitmq systemd stop script
     utils.deploy_blueprint_resource(
         '{0}/kill-rabbit'.format(CONFIG_PATH),
         '/usr/local/bin/kill-rabbit')
+    # TODO: create chmod in utils and convert all
     utils.chmod('500', '/usr/local/bin/kill-rabbit')
     utils.systemd.configure('rabbitmq')
 
@@ -139,18 +141,16 @@ def _install_rabbitmq():
 
 
 def main():
-
-    rabbitmq_endpoint_ip = ctx.node.properties['rabbitmq_endpoint_ip']
-
-    if not rabbitmq_endpoint_ip:
+    ctx.logger.info('Setting Broker IP runtime property.')
+    if not ctx.instance.runtime_properties.get('rabbitmq_endpoint_ip'):
         broker_ip = ctx.instance.host_ip
         _install_rabbitmq()
     else:
-        ctx.logger.info('External RabbitMQ Endpoint provided: '
-                        '{0}...'.format(rabbitmq_endpoint_ip))
-        broker_ip = rabbitmq_endpoint_ip
+        broker_ip = ctx.instance.runtime_properties.get('rabbitmq_endpoint_ip')
+        ctx.logger.info('Using external rabbitmq at {0}'.format(broker_ip))
 
     ctx.instance.runtime_properties['rabbitmq_endpoint_ip'] = broker_ip
+    ctx.logger.info('RabbitMQ Endpoint IP is: {0}'.format(broker_ip))
 
 
 main()


### PR DESCRIPTION
Reverts cloudify-cosmo/cloudify-manager-blueprints#264