### PR TITLE
ES create: copy scripts one-by-one

### DIFF
--- a/components/elasticsearch/scripts/create.py
+++ b/components/elasticsearch/scripts/create.py
@@ -152,6 +152,7 @@ def _install_elasticsearch():
     es_logs_path = "/var/log/cloudify/elasticsearch"
     es_conf_path = "/etc/elasticsearch"
     es_unit_override = "/etc/systemd/system/elasticsearch.service.d"
+    es_scripts_path = os.path.join(es_conf_path, 'scripts')
 
     ctx.logger.info('Installing Elasticsearch...')
     utils.set_selinux_permissive()
@@ -188,9 +189,10 @@ def _install_elasticsearch():
 
     ctx.logger.info('Creating Elasticsearch scripts folder and '
                     'additional external Elasticsearch scripts...')
+    utils.mkdir(es_scripts_path)
     utils.deploy_blueprint_resource(
-        os.path.join(CONFIG_PATH, 'scripts'),
-        os.path.join(es_conf_path, 'scripts')
+        os.path.join(CONFIG_PATH, 'scripts', 'append.groovy'),
+        os.path.join(es_scripts_path, 'append.groovy')
     )
 
     ctx.logger.info('Setting Elasticsearch Heap Size...')


### PR DESCRIPTION
There's no "deploy_blueprint_resource" equivalent for directories,
so we need to copy each script file separately (fortunately, there's
just one right now).

Further work might involve adding a method to copy a directory.