### PR TITLE
CFY-5009 File server on manager is accessible via other ports besides…

### DIFF
--- a/components/nginx/config/fileserver-location.cloudify
+++ b/components/nginx/config/fileserver-location.cloudify
@@ -1,4 +1,5 @@
   location ~ ^/resources {
+    internal;
     rewrite            /resources/(.*) /$1 break;
     proxy_pass         http://cloudify-resources;
     proxy_redirect     off;

--- a/components/nginx/config/http-rest-server.cloudify
+++ b/components/nginx/config/http-rest-server.cloudify
@@ -11,4 +11,7 @@ server {
 
   # Serves the Rest Service (backed by the cloudify-rest upstream).
   include "/etc/nginx/conf.d/rest-location.cloudify";
+
+  # Serves the File Server (backed by the cloudify-resources upstream).
+  include "/etc/nginx/conf.d/fileserver-location.cloudify";
 }

--- a/components/nginx/config/https-rest-server.cloudify
+++ b/components/nginx/config/https-rest-server.cloudify
@@ -20,4 +20,7 @@ server {
 
   # Serves the Rest Service (backed by the cloudify-rest upstream).
   include "/etc/nginx/conf.d/rest-location.cloudify";
+
+  # Serves the File Server (backed by the cloudify-resources upstream).
+  include "/etc/nginx/conf.d/fileserver-location.cloudify";
 }


### PR DESCRIPTION
… 53229

It seems that adding `internal;` fixed all of the problems: resources are still available via port 80, but only internally - in this case via an internal redirect. 