### PR TITLE
CFY-5255 REST service sanity check: bypass maintenance

### DIFF
--- a/components/nginx/scripts/start.py
+++ b/components/nginx/scripts/start.py
@@ -26,4 +26,11 @@ utils.start_service(NGINX_SERVICE_NAME, append_prefix=False)
 utils.systemd.verify_alive(NGINX_SERVICE_NAME, append_prefix=False)
 
 nginx_url = 'http://127.0.0.1/api/v2.1/blueprints'
-utils.verify_service_http(NGINX_SERVICE_NAME, nginx_url, check_response)
+
+if utils.is_upgrade or utils.is_rollback:
+    headers = utils.create_maintenance_headers()
+else:
+    headers = utils.get_auth_headers(True)
+
+utils.verify_service_http(NGINX_SERVICE_NAME, nginx_url, check_response,
+                          headers=headers)

--- a/components/restservice/scripts/start.py
+++ b/components/restservice/scripts/start.py
@@ -24,11 +24,17 @@ def verify_restservice(url):
     a good chance everything is configured correctly.
     """
     blueprints_url = urlparse.urljoin(url, 'api/v2.1/blueprints')
-    req = urllib2.Request(blueprints_url)
 
-    auth_headers = utils.get_auth_headers(True)
-    if 'Authorization' in auth_headers:
-        req.add_header('Authorization', auth_headers['Authorization'])
+    headers = utils.get_auth_headers(True)
+
+    if utils.is_upgrade or utils.is_rollback:
+        # if we're doing an upgrade, we're in maintenance mode - this request
+        # is safe to perform in maintenance mode, so let's bypass the check
+        headers = utils.create_maintenance_headers()
+    else:
+        headers = utils.get_auth_headers(True)
+
+    req = urllib2.Request(blueprints_url, headers=headers)
 
     try:
         response = urllib2.urlopen(req)


### PR DESCRIPTION
The endpoint we're using to check if the REST service is working
is unavailable in maintenance mode (so, when upgrading the manager).
Bypass the maintenance mode for that request.