### PR TITLE
Deploying files that are rendered: overwrite if they exist (Don't merge yet)

### DIFF
--- a/components/utils.py
+++ b/components/utils.py
@@ -876,7 +876,7 @@ class BlueprintResourceFactory(object):
         local_resource_path = self._get_local_file_path(service_name,
                                                         resource_name)
 
-        if not os.path.isfile(local_resource_path):
+        if not render and not os.path.isfile(local_resource_path):
             mkdir(os.path.dirname(local_resource_path))
             if user_resource:
                 self._download_user_resource(source,


### PR DESCRIPTION
Don't merge yet, needs discussion. Will be updated or closed as needed.

When deploying a file that needs rendering, if the file already exists,
still overwrite it: the template inputs might have changed.

Without this, config files don't get overwritten on upgrade.