### PR TITLE
CFY-4953 Move validation scripts to the simple manager blueprint

### DIFF
--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -567,11 +567,17 @@ node_templates:
           implementation: fabric.fabric_plugin.tasks.run_script
           inputs:
             script_path: components/manager/scripts/create_conf.py
-            fabric_env:
+            fabric_env: &simple_fabric_env
               user: { get_input: ssh_user }
               key_filename: { get_input: ssh_key_filename }
               host_string: { get_property: [manager_host, public_ip] }
               always_use_pty: true
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/manager/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
     relationships:
       - type: cloudify.relationships.contained_in
@@ -620,6 +626,13 @@ node_templates:
         target: manager_host
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/rabbitmq/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   elasticsearch:
     type: manager.nodes.Elasticsearch
@@ -630,6 +643,13 @@ node_templates:
         target: java_runtime
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/elasticsearch/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   logstash:
     type: manager.nodes.Logstash
@@ -642,6 +662,13 @@ node_templates:
         target: elasticsearch
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/logstash/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   influxdb:
     type: manager.nodes.InfluxDB
@@ -650,6 +677,13 @@ node_templates:
         target: manager_host
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/influxdb/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   nginx:
     type: manager.nodes.Nginx
@@ -660,6 +694,13 @@ node_templates:
         target: manager_configuration
       - type: nginx_to_restservice
         target: rest_service
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/nginx/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   riemann:
     type: manager.nodes.Riemann
@@ -674,6 +715,13 @@ node_templates:
         target: nginx
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/riemann/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   rest_service:
     type: manager.nodes.RestService
@@ -688,6 +736,13 @@ node_templates:
         target: elasticsearch
       - type: restservice_to_rabbitmq
         target: rabbitmq
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/restservice/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   mgmt_worker:
     type: manager.nodes.ManagementWorker
@@ -702,6 +757,13 @@ node_templates:
         target: nginx
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/mgmtworker/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   amqp_influx:
     type: manager.nodes.AmqpInfluxBroker
@@ -716,6 +778,13 @@ node_templates:
         target: influxdb
       - type: cloudify.relationships.depends_on
         target: manager_configuration
+    interfaces:
+      cloudify.interfaces.validation:
+        creation:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path: components/amqpinflux/scripts/creation_validation.py
+            fabric_env: *simple_fabric_env
 
   webui:
     type: manager.nodes.WebUI

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -165,14 +165,6 @@ node_types:
         description: Use existing manager configuration on upgrade
         type: string
         default: true
-    interfaces:
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/manager/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.PythonRuntime:
     derived_from: cloudify.nodes.SoftwareComponent
@@ -310,13 +302,6 @@ node_types:
             script_path:
               default: components/rabbitmq/scripts/stop.py
             fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/rabbitmq/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.Elasticsearch:
     derived_from: cloudify.nodes.DBMS
@@ -386,13 +371,6 @@ node_types:
             script_path:
               default: components/elasticsearch/scripts/stop.py
             fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/elasticsearch/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.Logstash:
     derived_from: cloudify.nodes.SoftwareComponent
@@ -442,13 +420,6 @@ node_types:
             script_path:
               default: components/logstash/scripts/stop.py
             fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/logstash/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.InfluxDB:
     derived_from: cloudify.nodes.DBMS
@@ -483,13 +454,6 @@ node_types:
           inputs:
             script_path:
               default: components/influxdb/scripts/stop.py
-            fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/influxdb/scripts/creation_validation.py
             fabric_env: *simple_fabric_env
 
   manager.nodes.Nginx:
@@ -539,13 +503,6 @@ node_types:
           inputs:
             script_path:
               default: components/nginx/scripts/stop.py
-            fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/nginx/scripts/creation_validation.py
             fabric_env: *simple_fabric_env
 
   manager.nodes.Riemann:
@@ -602,13 +559,6 @@ node_types:
           inputs:
             script_path:
               default: components/riemann/scripts/stop.py
-            fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/riemann/scripts/creation_validation.py
             fabric_env: *simple_fabric_env
 
   manager.nodes.RestService:
@@ -715,13 +665,6 @@ node_types:
             script_path:
               default: components/restservice/scripts/stop.py
             fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/restservice/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.ManagementWorker:
     derived_from: cloudify.nodes.ApplicationModule
@@ -813,13 +756,6 @@ node_types:
             script_path:
               default: components/mgmtworker/scripts/stop.py
             fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/mgmtworker/scripts/creation_validation.py
-            fabric_env: *simple_fabric_env
 
   manager.nodes.AmqpInfluxBroker:
     derived_from: cloudify.nodes.ApplicationModule
@@ -877,13 +813,6 @@ node_types:
           inputs:
             script_path:
               default: components/amqpinflux/scripts/stop.py
-            fabric_env: *simple_fabric_env
-      cloudify.interfaces.validation:
-        creation:
-          implementation: fabric.fabric_plugin.tasks.run_script
-          inputs:
-            script_path:
-              default: components/amqpinflux/scripts/creation_validation.py
             fabric_env: *simple_fabric_env
 
   manager.nodes.WebUI:


### PR DESCRIPTION
The upgrade validation scripts need to be uploaded to the target host,
so only do that in the simple blueprint, which requires having a
machine running.
The simple manager blueprint is the one that's used for upgrades
typically, anyway.