### PR TITLE
CFY-5384 utils.yum_install: don't break on repository packages

### DIFF
--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -474,14 +474,15 @@ inputs:
   # Dev Inputs
   #############################
 
+  # Some plugins installed from sources require compilation - installs a
+  # compiler and the python headers to allow that.
+  install_python_compilers:
+    type: boolean
+    default: false
+
   # For development purposes, you can use these, which will override the modules
   # supplied within the rpm.
   # These should be pip installable tar.gz files.
-  # Note that `install_python_compilers` must not be an empty string if one of the
-  # below modules require compilation.
-  install_python_compilers:
-    type: string
-    default: ''
 
   cli_source_url:
     type: string

--- a/components/utils.py
+++ b/components/utils.py
@@ -363,16 +363,22 @@ def yum_install(source, service_name):
     if ext.endswith('.rpm'):
         source_path = download_cloudify_resource(source, service_name)
 
-    rpm_handler = RpmPackageHandler(source_path)
-    ctx.logger.info('Checking whether {0} is already installed...'.format(
-        source_path))
-    if rpm_handler.is_rpm_installed():
-        ctx.logger.info('Package {0} is already installed.'.format(source))
-        return
+        rpm_handler = RpmPackageHandler(source_path)
+        ctx.logger.info('Checking whether {0} is already installed...'.format(
+            source_path))
+        if rpm_handler.is_rpm_installed():
+            ctx.logger.info('Package {0} is already installed.'.format(source))
+            return
 
-    # removes any existing versions of the package that do not match
-    # the provided package source version
-    rpm_handler.remove_existing_rpm_package()
+        # removes any existing versions of the package that do not match
+        # the provided package source version
+        rpm_handler.remove_existing_rpm_package()
+    else:
+        installed = run(['yum', '-q', 'list', 'installed', source_path],
+                        ignore_failures=True)
+        if installed.returncode == 0:
+            ctx.logger.info('Package {0} is already installed.'.format(source))
+            return
 
     ctx.logger.info('yum installing {0}...'.format(source_path))
     sudo(['yum', 'install', '-y', source_path])

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -512,14 +512,15 @@ inputs:
   # Dev Inputs
   #############################
 
+  # Some plugins installed from sources require compilation - installs a
+  # compiler and the python headers to allow that.
+  install_python_compilers:
+    type: boolean
+    default: false
+
   # For development purposes, you can use these, which will override the modules
   # supplied within the rpm.
   # These should be pip installable tar.gz files.
-  # Note that `install_python_compilers` must not be an empty string if one of the
-  # below modules require compilation.
-  install_python_compilers:
-    type: string
-    default: ''
 
   cli_source_url:
     type: string

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -425,14 +425,15 @@ inputs:
   # Dev Inputs
   #############################
 
+  # Some plugins installed from sources require compilation - installs a
+  # compiler and the python headers to allow that.
+  install_python_compilers:
+    type: boolean
+    default: false
+
   # For development purposes, you can use these, which will override the modules
   # supplied within the rpm.
   # These should be pip installable tar.gz files.
-  # Note that `install_python_compilers` must not be an empty string if one of the
-  # below modules require compilation.
-  install_python_compilers:
-    type: string
-    default: ''
 
   cli_source_url:
     type: string

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -175,7 +175,7 @@ node_types:
     derived_from: cloudify.nodes.SoftwareComponent
     properties:
       install_python_compilers:
-        type: string
+        type: boolean
         default: { get_input: install_python_compilers }
       pip_source_rpm_url:
         type: string

--- a/vcloud-manager-blueprint.yaml
+++ b/vcloud-manager-blueprint.yaml
@@ -591,14 +591,15 @@ inputs:
   # Dev Inputs
   #############################
 
+  # Some plugins installed from sources require compilation - installs a
+  # compiler and the python headers to allow that.
+  install_python_compilers:
+    type: boolean
+    default: false
+
   # For development purposes, you can use these, which will override the modules
   # supplied within the rpm.
   # These should be pip installable tar.gz files.
-  # Note that `install_python_compilers` must not be an empty string if one of the
-  # below modules require compilation.
-  install_python_compilers:
-    type: string
-    default: ''
 
   cli_source_url:
     type: string

--- a/vsphere-manager-blueprint.yaml
+++ b/vsphere-manager-blueprint.yaml
@@ -598,14 +598,15 @@ inputs:
   # Dev Inputs
   #############################
 
+  # Some plugins installed from sources require compilation - installs a
+  # compiler and the python headers to allow that.
+  install_python_compilers:
+    type: boolean
+    default: false
+
   # For development purposes, you can use these, which will override the modules
   # supplied within the rpm.
   # These should be pip installable tar.gz files.
-  # Note that `install_python_compilers` must not be an empty string if one of the
-  # below modules require compilation.
-  install_python_compilers:
-    type: string
-    default: ''
 
   cli_source_url:
     type: string


### PR DESCRIPTION
The yum_install function only handled .rpm files correctly. This
change also makes it handle repository packages, eg. "python-devel".
This is required so that the `install_python_compilers` flag can work.

Also changed the `install_python_compilers` flag to be a boolean.