### PR TITLE
CFY-5469 Use `rabbitmqctl stop` in systemd ExecStop

### DIFF
--- a/components/rabbitmq/config/cloudify-rabbitmq
+++ b/components/rabbitmq/config/cloudify-rabbitmq
@@ -1,1 +1,2 @@
 RABBITMQ_LOG_BASE="/var/log/cloudify/rabbitmq"
+RABBITMQ_PID_FILE="/tmp/rabbitmq.pid"

--- a/components/rabbitmq/config/cloudify-rabbitmq.service
+++ b/components/rabbitmq/config/cloudify-rabbitmq.service
@@ -4,11 +4,19 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-TimeoutStartSec=0
 Restart=on-failure
 EnvironmentFile=-/etc/sysconfig/cloudify-rabbitmq
+
+# avoid a race condition when creating the erlang cookie
+# see https://bugzilla.redhat.com/show_bug.cgi?id=1059913
+ExecStartPre=-/bin/sh -c "/usr/sbin/rabbitmqctl status > /dev/null 2>&1"
+
 ExecStart=/usr/sbin/rabbitmq-server
-ExecStop=/usr/local/bin/kill-rabbit
+ExecStartPost=/usr/sbin/rabbitmqctl wait /tmp/rabbitmq.pid
+
+ExecStop=/usr/sbin/rabbitmqctl stop /tmp/rabbitmq.pid
+ExecStopPost=-/usr/bin/rm /tmp/rabbitmq.pid
+
 LimitNOFILE={{ node.properties.rabbitmq_fd_limit }}
 
 [Install]

--- a/components/rabbitmq/config/kill-rabbit
+++ b/components/rabbitmq/config/kill-rabbit
@@ -1,4 +1,0 @@
-#! /usr/bin/env bash
-for proc in "$(/usr/bin/ps aux | /usr/bin/grep rabbitmq | /usr/bin/grep -v grep | /usr/bin/awk '{ print $2 }')"; do
-    /usr/bin/kill ${proc}
-done

--- a/components/rabbitmq/scripts/create.py
+++ b/components/rabbitmq/scripts/create.py
@@ -104,11 +104,6 @@ def _install_rabbitmq():
 
     utils.logrotate(RABBITMQ_SERVICE_NAME)
 
-    utils.deploy_blueprint_resource(
-        '{0}/kill-rabbit'.format(CONFIG_PATH),
-        '/usr/local/bin/kill-rabbit',
-        RABBITMQ_SERVICE_NAME)
-    utils.chmod('500', '/usr/local/bin/kill-rabbit')
     utils.systemd.configure(RABBITMQ_SERVICE_NAME)
 
     ctx.logger.info('Configuring File Descriptors Limit...')


### PR DESCRIPTION
The systemd unit for rabbitmq uses commands that start and stop rabbit
in a blocking fashion - it is started/stopped before the script
returns. This is required for correct interop with systemd.