### PR TITLE
CFY-4953 Preupgrade validation fixups

### DIFF
--- a/components/manager/scripts/creation_validation.py
+++ b/components/manager/scripts/creation_validation.py
@@ -10,7 +10,6 @@ ctx.download_resource(
 import utils  # NOQA
 
 IMMUTABLE_PROPERTIES = [
-    'ssl',
     'security',
     'ssh_user'
 ]

--- a/components/rabbitmq/scripts/creation_validation.py
+++ b/components/rabbitmq/scripts/creation_validation.py
@@ -17,7 +17,8 @@ IMMUTABLE_PROPERTIES = [
     'rabbitmq_password',
     'rabbitmq_endpoint_ip',
     'rabbitmq_ssl_enabled',
-    'broker_cert_path'
+    'rabbitmq_cert_public',
+    'rabbitmq_cert_private'
 ]
 
 if utils.is_upgrade:


### PR DESCRIPTION
  - 'ssl' is not a separate property, it's nested under 'security'
  - rabbitmq cert properties are rabbitmq_cert_*, not broker_cert_path