### PR TITLE
Allow installing the DSL parser from source in mgmtworker create script

### DIFF
--- a/components/mgmtworker/scripts/create.py
+++ b/components/mgmtworker/scripts/create.py
@@ -20,6 +20,8 @@ ctx_properties = utils.ctx_factory.create(MGMT_WORKER_SERVICE_NAME)
 def _install_optional(mgmtworker_venv):
 
     rest_props = utils.ctx_factory.get('restservice')
+    dsl_parser_source_url = \
+        rest_props['dsl_parser_module_source_url']
     rest_client_source_url = \
         rest_props['rest_client_module_source_url']
     plugins_common_source_url = \
@@ -33,6 +35,8 @@ def _install_optional(mgmtworker_venv):
 
     # this allows to upgrade modules if necessary.
     ctx.logger.info('Installing Optional Packages if supplied...')
+    if dsl_parser_source_url:
+        utils.install_python_package(dsl_parser_source_url, mgmtworker_venv)
     if rest_client_source_url:
         utils.install_python_package(rest_client_source_url, mgmtworker_venv)
     if plugins_common_source_url:


### PR DESCRIPTION
The mgmtworker create script allows installing prerequisite packages
from source, like the REST service create script, but it omitted
the DSL parser package (which is required for the rest-service).