### PR TITLE
CFY-5672 Autogenerate token auth secret_key

### DIFF
--- a/components/restservice/scripts/preconfigure.py
+++ b/components/restservice/scripts/preconfigure.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-import tempfile
 import os
+import json
+import binascii
+import tempfile
 from os.path import join, dirname
 
 from cloudify import ctx
@@ -13,17 +15,45 @@ import utils  # NOQA
 
 REST_SERVICE_NAME = 'restservice'
 
+TOKEN_AUTHENTICATOR = \
+    'flask_securest.authentication_providers.token:TokenAuthenticator'
+
+
+def add_transient_security_properties(settings):
+    """Add security-related properties that should change for each manager.
+
+    Some values (like the token generator secret key) should be different
+    for each manager, because reusing them would be a security issue.
+    Examine the security config, generate the required values and add
+    them to settings.
+    """
+    secret_key = binascii.hexlify(os.urandom(32))
+    for auth_provider in settings.get('authentication_providers', []):
+        if auth_provider.get('implementation') == TOKEN_AUTHENTICATOR:
+            if 'properties' not in auth_provider:
+                auth_provider['properties'] = {}
+            auth_provider['properties']['secret_key'] = secret_key
+
+    auth_token_generator = settings.get('auth_token_generator')
+    if auth_token_generator and auth_token_generator.get('implementation') \
+            == TOKEN_AUTHENTICATOR:
+        if 'properties' not in auth_token_generator:
+            auth_token_generator['properties'] = {}
+        auth_token_generator['properties']['secret_key'] = secret_key
+
 
 def preconfigure_restservice():
 
     rest_service_home = '/opt/manager'
 
     ctx.logger.info('Deploying REST Security configuration file...')
-    sec_config = utils.load_manager_config_prop('security')
+    sec_config = json.loads(utils.load_manager_config_prop('security'))
+    add_transient_security_properties(sec_config)
+
     fd, path = tempfile.mkstemp()
     os.close(fd)
     with open(path, 'w') as f:
-        f.write(sec_config)
+        json.dump(sec_config, f)
     utils.move(path, os.path.join(rest_service_home, 'rest-security.conf'))
 
     utils.systemd.configure(REST_SERVICE_NAME, render=False)

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -112,7 +112,6 @@ node_types:
             - name: token
               implementation: flask_securest.authentication_providers.token:TokenAuthenticator
               properties:
-                secret_key: my_secret
           authorization_provider:
             implementation: flask_securest.authorization_providers.role_based_authorization_provider:RoleBasedAuthorizationProvider
             properties:
@@ -150,7 +149,6 @@ node_types:
           auth_token_generator:
             implementation: flask_securest.authentication_providers.token:TokenAuthenticator
             properties:
-              secret_key: my_secret
               expires_in_seconds: 600
           #########################################################################
           # Enabling SSL limits communication with the server to SSL only.


### PR DESCRIPTION
There is no need for the user to ever care about the secret_key value,
the only thing that matters is that it isn't easy to guess (or repeated across
hosts).

Try to see if the auth token generator is used, and if it is, generate a safe
secret_key during bootstrap.