### PR TITLE
CFY-5698 Remove `--pidfile` argument from the celery call in its unit file

### DIFF
--- a/components/mgmtworker/config/cloudify-mgmtworker.service
+++ b/components/mgmtworker/config/cloudify-mgmtworker.service
@@ -18,7 +18,6 @@ ExecStart=/opt/mgmtworker/env/bin/celery worker \
     --loglevel=${CELERY_LOG_LEVEL} \
     --queues=cloudify.management \
     --logfile=${CELERY_LOG_DIR}/cloudify.management_worker.log \
-    --pidfile=${CELERY_WORK_DIR}/cloudify.management_worker.pid \
     --autoscale={{ node.properties.max_workers }},{{ node.properties.min_workers }} \
     --without-gossip \
     --without-mingle \

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -4,7 +4,6 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-PIDFile=/var/run/gunicorn.pid
 TimeoutStartSec=0
 Restart=on-failure
 EnvironmentFile=-/etc/sysconfig/cloudify-restservice


### PR DESCRIPTION
In addition, removed the `PIDFile` entry from the gunicorn unit file as
it has no effect since the `Type` entry defaults to `simple`.