### PR TITLE
CFY-6000 Install components required by the manager HA cluster

### DIFF
--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -121,7 +121,7 @@ inputs:
       Set this to true if you want Telecom Edition
     type: boolean
     default: false
-    
+
 dsl_definitions:
   aws_configuration: &aws_configuration
     aws_access_key_id: { get_input: aws_access_key_id }
@@ -319,6 +319,16 @@ node_templates:
       - type: cloudify.aws.relationships.instance_connected_to_elastic_ip
         target: manager_server_ip
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -351,6 +361,14 @@ node_templates:
   ######################################################################
   # These are the nodes comprising the Cloudify Manager's components
   ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -372,6 +390,16 @@ node_templates:
         target: java_runtime
       - type: elasticsearch_to_manager_configuration
         target: manager_configuration
+
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
 
   postgresql:
     type: manager.nodes.Postgresql

--- a/azure-manager-blueprint.yaml
+++ b/azure-manager-blueprint.yaml
@@ -520,6 +520,16 @@ node_templates:
     - type: cloudify.azure.relationships.connected_to_ip_configuration
       target: vm_nic_ip_cfg
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -553,6 +563,14 @@ node_templates:
   ######################################################################
   # These are the nodes comprising the Cloudify Manager's components
   ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -574,6 +592,16 @@ node_templates:
         target: java_runtime
       - type: elasticsearch_to_manager_configuration
         target: manager_configuration
+
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
 
   postgresql:
     type: manager.nodes.Postgresql

--- a/components/consul/scripts/create.py
+++ b/components/consul/scripts/create.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import tempfile
+import zipfile
+
+from os.path import join, dirname
+
+from cloudify import ctx
+
+ctx.download_resource(
+    join('components', 'utils.py'),
+    join(dirname(__file__), 'utils.py'))
+import utils  # NOQA
+
+
+CONSUL_SERVICE_NAME = 'consul'
+ctx_properties = utils.ctx_factory.create(CONSUL_SERVICE_NAME)
+
+
+def install_consul():
+    consul_binary = '/opt/cloudify/consul/consul'
+    consul_config_dir = '/etc/consul.d'
+
+    utils.mkdir(dirname(consul_binary))
+    utils.mkdir(consul_config_dir)
+
+    consul_package = \
+        utils.download_cloudify_resource(ctx_properties['consul_package_url'],
+                                         CONSUL_SERVICE_NAME)
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        with zipfile.ZipFile(consul_package) as consul_archive:
+            consul_archive.extractall(temp_dir)
+
+        utils.move(join(temp_dir, 'consul'), consul_binary)
+        utils.chmod('+x', consul_binary)
+    finally:
+        utils.remove(temp_dir)
+
+
+install_consul()

--- a/components/keepalived/scripts/create.py
+++ b/components/keepalived/scripts/create.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from os.path import join, dirname
+
+from cloudify import ctx
+
+ctx.download_resource(
+    join('components', 'utils.py'),
+    join(dirname(__file__), 'utils.py'))
+import utils  # NOQA
+
+
+KEEPALIVED_SERVICE_NAME = 'keepalived'
+ctx_properties = utils.ctx_factory.create(KEEPALIVED_SERVICE_NAME)
+
+
+def install_keepalived():
+    keepalived_rpm_url = ctx_properties['keepalived_rpm_url']
+    utils.yum_install(keepalived_rpm_url,
+                      service_name=KEEPALIVED_SERVICE_NAME)
+
+install_keepalived()

--- a/components/postgresql/scripts/create.py
+++ b/components/postgresql/scripts/create.py
@@ -27,6 +27,8 @@ def _install_postgresql():
     ps_server_rpm_url = ctx_properties['ps_server_rpm_url']
     ps_devel_rpm_url = ctx_properties['ps_devel_rpm_url']
     psycopg2_rpm_url = ctx_properties['psycopg2_rpm_url']
+    repmgr_rpm_url = ctx_properties['repmgr_rpm_url']
+    pgbouncer_rpm_url = ctx_properties['pgbouncer_rpm_url']
 
     ctx.logger.info('Installing PostgreSQL dependencies...')
     utils.yum_install(source=libxslt_rpm_url, service_name=PS_SERVICE_NAME)
@@ -40,6 +42,10 @@ def _install_postgresql():
 
     ctx.logger.info('Installing python libs for PostgreSQL...')
     utils.yum_install(source=psycopg2_rpm_url, service_name=PS_SERVICE_NAME)
+
+    ctx.logger.info('Installing replication tools for PostgreSQL...')
+    utils.yum_install(source=repmgr_rpm_url, service_name=PS_SERVICE_NAME)
+    utils.yum_install(source=pgbouncer_rpm_url, service_name=PS_SERVICE_NAME)
 
 
 def _init_postgresql():

--- a/components/syncthing/scripts/create.py
+++ b/components/syncthing/scripts/create.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from os.path import join, dirname
+
+from cloudify import ctx
+
+ctx.download_resource(
+    join('components', 'utils.py'),
+    join(dirname(__file__), 'utils.py'))
+import utils  # NOQA
+
+
+SYNCTHING_SERVICE_NAME = 'syncthing'
+ctx_properties = utils.ctx_factory.create(SYNCTHING_SERVICE_NAME)
+
+
+def install_syncthing():
+    syncthing_package = \
+        utils.download_cloudify_resource(
+            ctx_properties['syncthing_package_url'], SYNCTHING_SERVICE_NAME)
+    utils.untar(syncthing_package, destination='/opt/cloudify/syncthing')
+
+
+install_syncthing()

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -196,6 +196,14 @@ inputs:
     type: string
     default: python-psycopg2-2.5.1-3.el7.x86_64.rpm
 
+  repmgr_rpm_url:
+    type: string
+    default: repmgr95-3.1.3-1.rhel7.x86_64.rpm
+
+  pgbouncer_rpm_url:
+    type: string
+    default: pgbouncer-1.7.2-5.rhel7.x86_64.rpm
+
   logstash_source_url:
     type: string
     default: logstash-1.5.0-1.noarch.rpm
@@ -223,6 +231,26 @@ inputs:
   nodejs_source_url:
     type: string
     default: node-v0.10.35-linux-x64.tar.gz
+
+  keepalived_rpm_url:
+    type: string
+    default: keepalived-1.2.13-7.el7.x86_64.rpm
+
+  #############################
+  # Consul Inputs
+  #############################
+
+  consul_package_url:
+    type: string
+    default: consul_0.6.4_linux_amd64.zip
+
+  #############################
+  # Syncthing Inputs
+  #############################
+
+  syncthing_package_url:
+    type: string
+    default: syncthing-linux-amd64-v0.14.5.tar.gz
 
   #############################
   # RabbitMQ Inputs

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -156,7 +156,7 @@ inputs:
       Set this to true if you want Telecom Edition
     type: boolean
     default: false
-    
+
 dsl_definitions:
   openstack_configuration: &openstack_configuration
     username: { get_input: keystone_username }
@@ -405,6 +405,16 @@ node_templates:
       - target: manager_server_ip
         type: cloudify.openstack.server_connected_to_floating_ip
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -437,6 +447,14 @@ node_templates:
   ######################################################################
   # These are the nodes comprising the Cloudify Manager's components
   ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -459,6 +477,16 @@ node_templates:
       - type: elasticsearch_to_manager_configuration
         target: manager_configuration
 
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
+
   postgresql:
     type: manager.nodes.Postgresql
     relationships:
@@ -466,6 +494,8 @@ node_templates:
         target: manager_host
       - type: cloudify.relationships.depends_on
         target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
 
   logstash:
     type: manager.nodes.Logstash

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -185,6 +185,16 @@ node_templates:
                 rest_host_internal_endpoint_type: { get_property: [rest_service, rest_host_internal_endpoint_type] }
                 rest_host_external_endpoint_type: { get_property: [rest_service, rest_host_external_endpoint_type] }
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -217,6 +227,14 @@ node_templates:
   # ######################################################################
   # # These are the nodes comprising the Cloudify Manager's components
   # ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -255,6 +273,16 @@ node_templates:
             hide_output: *hide_output
             fabric_env: *simple_fabric_env
 
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
+
   postgresql:
     type: manager.nodes.Postgresql
     relationships:
@@ -262,6 +290,8 @@ node_templates:
         target: manager_host
       - type: cloudify.relationships.depends_on
         target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
     interfaces:
       cloudify.interfaces.validation:
         creation:

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -224,6 +224,52 @@ node_types:
             hide_output: *hide_output
             fabric_env: *simple_fabric_env
 
+  manager.nodes.Consul:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      consul_package_url:
+        default: { get_input: consul_package_url }
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path:
+              default: components/consul/scripts/create.py
+            hide_output: *hide_output
+            fabric_env: *simple_fabric_env
+
+  manager.nodes.Keepalived:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      keepalived_rpm_url:
+        description: Keepalived RPM package URL
+        default: { get_input: keepalived_rpm_url }
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path:
+              default: components/keepalived/scripts/create.py
+            hide_output: *hide_output
+            fabric_env: *simple_fabric_env
+
+  manager.nodes.Syncthing:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      syncthing_package_url:
+        default: { get_input: syncthing_package_url}
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: fabric.fabric_plugin.tasks.run_script
+          inputs:
+            script_path:
+              default: components/syncthing/scripts/create.py
+            hide_output: *hide_output
+            fabric_env: *simple_fabric_env
+
   manager.nodes.RabbitMQ:
     derived_from: cloudify.nodes.MessageBusServer
     properties:
@@ -419,6 +465,12 @@ node_types:
       psycopg2_rpm_url:
         type: string
         default: { get_input: python_psycopg2_rpm_url }
+      repmgr_rpm_url:
+        type: string
+        default: { get_input: repmgr_rpm_url }
+      pgbouncer_rpm_url:
+        type: string
+        default: { get_input: pgbouncer_rpm_url }
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/vcloud-manager-blueprint.yaml
+++ b/vcloud-manager-blueprint.yaml
@@ -228,7 +228,7 @@ inputs:
       Set this to true if you want Telecom Edition
     type: boolean
     default: false
-    
+
 ######################################################################
 # This is a vcloud blueprint specific node_type to allow us to define
 # The public_ip of the machine is an accessible property of the host.
@@ -512,6 +512,16 @@ node_templates:
       - type: cloudify.relationships.depends_on
         target: manager_public_ip
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -544,6 +554,14 @@ node_templates:
   ######################################################################
   # These are the nodes comprising the Cloudify Manager's components
   ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -565,6 +583,16 @@ node_templates:
         target: java_runtime
       - type: elasticsearch_to_manager_configuration
         target: manager_configuration
+
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
 
   postgresql:
     type: manager.nodes.Postgresql

--- a/vsphere-manager-blueprint.yaml
+++ b/vsphere-manager-blueprint.yaml
@@ -241,7 +241,7 @@ inputs:
       Set this to true if you want Telecom Edition
     type: boolean
     default: false
-    
+
 ######################################################################
 # This is a vsphere blueprint specific node_type to allow us to define
 # The public_ip of the machine is an accessible property of the host.
@@ -398,6 +398,16 @@ node_templates:
                 rest_host_internal_endpoint_type: { get_property: [rest_service, rest_host_internal_endpoint_type] }
                 rest_host_external_endpoint_type: { get_property: [rest_service, rest_host_external_endpoint_type] }
 
+  keepalived:
+    type: manager.nodes.Keepalived
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   # #####################################################################
   # The Python and Java nodes are used to provide runtime environments
   # on specific hosts. It allows us to define the runtime environment
@@ -430,6 +440,14 @@ node_templates:
   ######################################################################
   # These are the nodes comprising the Cloudify Manager's components
   ######################################################################
+  consul:
+    type: manager.nodes.Consul
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+
   rabbitmq:
     type: manager.nodes.RabbitMQ
     relationships:
@@ -451,6 +469,16 @@ node_templates:
         target: java_runtime
       - type: elasticsearch_to_manager_configuration
         target: manager_configuration
+
+  syncthing:
+    type: manager.nodes.Syncthing
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_resources
+      - type: cloudify.relationships.depends_on
+        target: consul
 
   postgresql:
     type: manager.nodes.Postgresql


### PR DESCRIPTION
Install all the required packages. Don't configure them yet, configuration will be
on demand, enabled on an already running manager.
This just makes sure all the packages are there.