### PR TITLE
CFY-6070. Configure rest service worker count

### DIFF
--- a/aws-ec2-manager-blueprint-inputs.yaml
+++ b/aws-ec2-manager-blueprint-inputs.yaml
@@ -309,6 +309,13 @@ aws_secret_access_key: ''
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/azure-manager-blueprint-inputs.yaml
+++ b/azure-manager-blueprint-inputs.yaml
@@ -30,3 +30,282 @@ ssh_user: centos
 resource_prefix: lwr
 resource_suffix: 00
 retry_after: 30
+
+#############################
+# Security Settings
+#############################
+# Enabling SSL limits communication with the server to SSL only.
+# NOTE: If enabled, the certificate and private key files must reside in resources/ssl.
+#ssl_enabled: false
+
+# If SSL is enabled, agent requests to the REST service verify its certificate
+# by default. To disable certificate verification, set this value to false.
+#agent_verify_rest_certificate: true
+
+# Username and password of the Cloudify administrator.
+# This user will also be included in the simple userstore repostiroty if the
+# simple userstore implementation is used.
+#admin_username: 'admin'
+#admin_password: ''
+
+#insecure_endpoints_disabled: true
+
+# Default locations for certificates on agents
+#agent_rest_cert_path: '~/.cloudify/certs/rest.crt'
+#broker_ssl_cert_path: '~/.cloudify/certs/broker.crt'
+
+#############################
+# Bootstrap Validations
+#############################
+# Validations are performed to check that attributes like disk space and memory
+# correspond with some prerequisites and that some resources are available for
+# download.
+# Setting to `true` will allow to ignore those validations.
+#ignore_bootstrap_validations: false
+
+# These allow to override specific validation values
+# NOTE: We do not recommend changing these values unless you know exactly
+# what you're doing.
+#minimum_required_total_physical_memory_in_mb: 3792
+#minimum_required_available_disk_space_in_gb: 5
+#allowed_heap_size_gap_in_mb: 1000
+
+#############################
+# Manager Resources Package
+#############################
+#manager_resources_package: http://repository.cloudifysource.org/org/cloudify3/4.0.0/m7-RELEASE/cloudify-manager-resources_4.0.0-m7-b467.tar.gz
+
+# Providing a checksum file url will allow validating the resources package.
+# By default, no validation is performed. Providing a checksum file will use
+# the file to validate. Note that not providing a file but changing
+# `skip_checksum_validation` to false means we will try to guess the location
+# of an md5 checksum file and validate against it.
+# You can download our md5 checksum file by appending .md5
+# to the `manager_resources_package` url.
+#manager_resources_package_checksum_file: ''
+#skip_checksum_validation: true
+#############################
+# Agent Packages
+#############################
+
+# The key names must be in the format: distro_release_agent (e.g. ubuntu_trusty_agent)
+# as the key is what's used to name the file, which later allows our
+# agent installer to identify it for your distro and release automatically.
+# Note that the windows agent key name MUST be `cloudify_windows_agent`
+#agent_package_urls:
+#  ubuntu_trusty_agent: ''
+#  ubuntu_precise_agent: ''
+#  centos_7x_agent: ''
+#  centos_6x_agent: ''
+#  redhat_7x_agent: ''
+#  redhat_6x_agent: ''
+#  cloudify_windows_agent: ''
+
+#############################
+# Cloudify Modules
+#############################
+
+# Note that you can replace rpm urls with names of packages as long as they're available in your default yum repository.
+# That is, as long as they provide the exact same version of that module.
+
+#rest_service_rpm_source_url: ''
+#management_worker_rpm_source_url: ''
+#amqpinflux_rpm_source_url: ''
+#cloudify_resources_url: ''
+#webui_source_url: ''
+
+# This is a Cloudify specific redistribution of Grafana.
+#grafana_source_url: ''
+
+#############################
+# External Components
+#############################
+
+# Note that you can replace rpm urls with names of packages as long as they're available in your default yum repository.
+# That is, as long as they provide the exact same version of that module.
+
+#pip_source_rpm_url: ''
+#java_source_url: ''
+
+# RabbitMQ Distribution of Erlang
+#erlang_source_url: ''
+#rabbitmq_source_url: ''
+
+#elasticsearch_source_url: ''
+#elasticsearch_curator_rpm_source_url: ''
+
+#logstash_source_url: ''
+#nginx_source_url: ''
+#influxdb_source_url: ''
+
+#riemann_source_url: ''
+# A RabbitMQ Client for Riemann
+#langohr_source_url: ''
+# Riemann's default daemonizer
+#daemonize_source_url: ''
+
+#nodejs_source_url: ''
+
+##################################
+# Management Workers configuration
+##################################
+
+# Sets the logging level to use for the management workers. This affects the logging performed
+# by the manager during the execution of management tasks, such as deployment creation
+# and deployment deletion.
+# NOTE: specifying "debug" will result in considerable amount of logging activity. Consider
+# using "info" (or a more restrictive level) for production environments.
+#management_worker_log_level: debug
+
+#############################
+# RabbitMQ Configuration
+#############################
+# Sets the username/password to use for clients such as celery
+# to connect to the rabbitmq broker.
+# It is recommended that you set both the username and password
+# to something reasonably secure.
+#rabbitmq_username: 'cloudify'
+#rabbitmq_password: 'c10udify'
+
+# Enable SSL for RabbitMQ. If this is set to true then the public and private
+# certs must be supplied (`rabbitmq_cert_private`, `rabbitmq_cert_public` inputs).
+#rabbitmq_ssl_enabled: false
+
+# The private certificate for RabbitMQ to use for SSL. This must be PEM formatted.
+# It is expected to begin with a line containing 'PRIVATE KEY' in the middle.
+#rabbitmq_cert_private: ''
+
+# The public certificate for RabbitMQ to use for SSL. This does not need to be signed by any CA,
+# as it will be deployed and explicitly used for all other components.
+# It may be self-signed. It must be PEM formatted.
+# It is expected to begin with a line of dashes with 'BEGIN CERTIFICATE' in the middle.
+# If an external endpoint is used, this must be the public certificate associated with the private
+# certificate that has already been configured for use by that rabbit endpoint.
+#rabbitmq_cert_public: ''
+
+# Allows to define the message-ttl for the different types of queues (in milliseconds).
+# These are not used if `rabbitmq_endpoint_ip` is provided.
+# https://www.rabbitmq.com/ttl.html
+#rabbitmq_events_queue_message_ttl: 60000
+#rabbitmq_logs_queue_message_ttl: 60000
+#rabbitmq_metrics_queue_message_ttl: 60000
+
+# This will set the queue length limit. Note that while new messages
+# will be queued in RabbitMQ, old messages will be deleted once the
+# limit is reached!
+# These are not used if `rabbitmq_endpoint_ip` is provided.
+# Note this is NOT the message byte length!
+# https://www.rabbitmq.com/maxlength.html
+#rabbitmq_events_queue_length_limit: 1000000
+#rabbitmq_logs_queue_length_limit: 1000000
+#rabbitmq_metrics_queue_length_limit: 1000000
+
+# RabbitMQ File Descriptors Limit
+#rabbitmq_fd_limit: 102400
+
+# You can configure an external endpoint of a RabbitMQ Cluster to use
+# instead of the built in one.
+# If one is provided, the built in RabbitMQ cluster will not run.
+# Also note that your external cluster must be preconfigured with any
+# user name/pass and SSL certs if you plan on using RabbitMQ's security
+# features.
+#rabbitmq_endpoint_ip: ''
+
+#############################
+# Elasticsearch Configuration
+#############################
+# bootstrap.mlockall is set to true by default.
+# This allows to set the heapsize for your cluster.
+# https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html
+#elasticsearch_heap_size: 2g
+
+# This allows to provide any JAVA_OPTS to Elasticsearch.
+#elasticsearch_java_opts: ''
+
+# The index for events will be named `logstash-YYYY.mm.dd`.
+# A new index corresponding with today's date will be added each day.
+# Elasticsearch Curator is used to rotate the indices on a daily basis
+# via a cronjob. This allows to determine the number of days to keep.
+#elasticsearch_index_rotation_interval: 7
+
+# You can configure an external endpoint of an Elasticsearch Cluster to use
+# instead of the built in one. The built in Elasticsearch cluster will not run.
+# You need to provide an IP (defaults to localhost) and Port (defaults to 9200) of your Elasticsearch Cluster.
+#elasticsearch_endpoint_ip: ''
+#elasticsearch_endpoint_port: 9200
+
+# You can enable automatic clustering of elasticsearch nodes and choose the port in which multicast discovery
+# is performed. Note that when bootstrapping two managers on the same network, if enabling clustering, you must
+# use a different port as to prevent clustering. This can be either 'true' or 'false'.
+# Must be quoted to be passed as a string.
+#elasticsearch_clustering_enabled: 'false'
+#elasticsearch_clustering_discovery_port: 54329
+
+#############################
+# PostgreSQL Configuration
+#############################
+# You can configure the PostgreSQL database name for cloudify
+#postgresql_db_name: 'cloudify_db'
+#postgresql_host: 'localhost'
+
+#############################
+# LDAP Configuration
+#############################
+#ldap_server: ''
+#ldap_username: ''
+#ldap_password: ''
+#ldap_domain: ''
+#ldap_is_active_directory: true
+#ldap_dn_extra: ''
+
+#############################
+# InfluxDB Configuration
+#############################
+# You can configure an external endpoint of an InfluxDB Cluster to use
+# instead of the built in one.
+# If one is provided, the built in InfluxDB cluster will not run.
+# Note that the port is currently not configurable and must remain 8086.
+# Also note that the database username and password are hardcoded to root:root.
+#influxdb_endpoint_ip: ''
+
+#################################
+# Management Worker Configuration
+#################################
+# Maximum number of worker processes started by the management worker.
+#management_worker_max_workers: 100
+
+# Minimum number of worker processes maintained by the management worker.
+#management_worker_min_workers: 2
+
+#################################
+# REST Configuration
+#################################
+# valid values: public_ip, private_ip
+#rest_host_external_endpoint_type: public_ip
+
+# valid values: public_ip, private_ip
+#rest_host_internal_endpoint_type: private_ip
+
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
+
+#############################
+# Offline Resources Upload
+#############################
+# You can configure a set of resources to upload at bootstrap. These resources
+# will reside on the manager and enable offline deployment. `dsl_resources`
+# should contain any resource needed in the parsing process (i.e. plugin.yaml files)
+
+#dsl_resources:
+#  - {'source_path': 'http://www.getcloudify.org/spec/fabric-plugin/1.4.2/plugin.yaml', 'destination_path': '/spec/fabric-plugin/1.4.2/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/script-plugin/1.4/plugin.yaml', 'destination_path': '/spec/script-plugin/1.4/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/diamond-plugin/1.3.4/plugin.yaml', 'destination_path': '/spec/diamond-plugin/1.3.4/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/aws-plugin/1.4.1/plugin.yaml', 'destination_path': '/spec/aws-plugin/1.4.1/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/openstack-plugin/1.5/plugin.yaml', 'destination_path': '/spec/openstack-plugin/1.5/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/tosca-vcloud-plugin/1.3.1/plugin.yaml', 'destination_path': '/spec/tosca-vcloud-plugin/1.3.1/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/vsphere-plugin/2.0.1/plugin.yaml', 'destination_path': '/spec/vsphere-plugin/2.0.1/plugin.yaml'}
+#  - {'source_path': 'http://www.getcloudify.org/spec/cloudify/4.0m7/types.yaml', 'destination_path': '/spec/cloudify/4.0m7/types.yaml'}

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -9,7 +9,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /var/run/gunicorn.pid \
-    -w $(($(nproc)*2+1)) \
+    -w {{ node.properties.gunicorn_worker_count or '$(($(nproc)*2+1))' }} \
     -b 0.0.0.0:${REST_PORT} \
     --timeout 300 manager_rest.server:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \

--- a/components/restservice/scripts/configure.py
+++ b/components/restservice/scripts/configure.py
@@ -95,7 +95,7 @@ def _log_results(result):
 
 def configure_restservice():
     _deploy_security_configuration()
-    utils.systemd.configure(REST_SERVICE_NAME, render=False)
+    utils.systemd.configure(REST_SERVICE_NAME)
     _create_db_tables_and_add_users()
 
 

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -38,6 +38,13 @@ inputs:
   rest_host_internal_endpoint_type:
     default: private_ip
 
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+    type: integer
+    default: 0
+
   #############################
   # Bootstrap Validations
   #############################

--- a/openstack-manager-blueprint-inputs.yaml
+++ b/openstack-manager-blueprint-inputs.yaml
@@ -317,6 +317,13 @@ external_network_name: ''
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/simple-manager-blueprint-inputs.yaml
+++ b/simple-manager-blueprint-inputs.yaml
@@ -278,6 +278,13 @@
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/tests/unit-tests/test_restservice.py
+++ b/tests/unit-tests/test_restservice.py
@@ -1,0 +1,50 @@
+import os
+
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+)
+from testtools import TestCase
+from testtools.matchers import Contains
+
+
+class TestRestServiceFile(TestCase):
+
+    """Test service file."""
+
+    TEMPLATE_DIR = os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        'components',
+        'restservice',
+        'config',
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        """Get template object."""
+        env = Environment(loader=FileSystemLoader(cls.TEMPLATE_DIR))
+        cls.template = env.get_template('cloudify-restservice.service')
+
+    def test_render_default(self):
+        """Render template using 0 as the worker count."""
+        text = self.template.render(node={
+            'properties': {
+                'gunicorn_worker_count': 0,
+            },
+        })
+        self.assertThat(text, Contains('-w $(($(nproc)*2+1)) \\'))
+
+    def test_render_integer(self):
+        """Render template using an integer as the worker count."""
+        expected_worker_count = 12345
+        text = self.template.render(node={
+            'properties': {
+                'gunicorn_worker_count': expected_worker_count,
+            },
+        })
+        self.assertThat(
+            text,
+            Contains('-w {0} \\'.format(expected_worker_count)),
+        )

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -743,9 +743,9 @@ node_types:
       gunicorn_worker_count:
         description: |
           The number of worker processes for handling requests.
-          Default value (0), means to use 2 * cpu_count + 1 processes.
+          If value is set to 0, then (2 * cpu_count + 1 processes) will be used.
         type: integer
-        default: 0
+        default: { get_input: rest_service_gunicorn_worker_count }
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -740,6 +740,12 @@ node_types:
         description: Use existing elasticsearch configuration
         type: string
         default: true
+      gunicorn_worker_count:
+        description: |
+          The number of worker processes for handling requests.
+          Default value (0), means to use 2 * cpu_count + 1 processes.
+        type: integer
+        default: 0
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/vcloud-manager-blueprint-inputs.yaml
+++ b/vcloud-manager-blueprint-inputs.yaml
@@ -346,6 +346,13 @@ user_public_key: ssh-rsa...
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/vsphere-manager-blueprint-inputs.yaml
+++ b/vsphere-manager-blueprint-inputs.yaml
@@ -344,6 +344,13 @@
 
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
+#
+#rest_service_gunicorn_worker_count:
+#  description: |
+#    The number of worker processes for handling requests.
+#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#  type: integer
+#  default: 0
 
 #############################
 # Offline Resources Upload


### PR DESCRIPTION
In this PR, a new property is added to `manager.nodes.RestService` called `gunicorn_worker_count` that can be used to configure how many worker nodes should be used to handle requests. This property by default gets its value from the `rest_service_gunicorn_worker_count` input which has been added to the inputs files under the *REST configuration* section with a default value of `0`.

The property value is used in the context passed to the template to render the `cloudify-restservice.service` systemd file that is used to launch the rest service. In particular, it's used to set the value of the `-w` option that sets the number of worker processes that will be used. The logic in the template is as follows:
- For a falsy value (0): it will render the the old default of `$(($(nproc)*2+1))`
- For a truthy value: it will render the value itself

With regard to test cases, the rendering of the template is checked at the rendering level, that is, using jinja directly and the general behavior of the number of processes launched in a bootstrapped manager has been checked manually.