### PR TITLE
CFY-6090. Fix download error

### DIFF
--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -44,14 +44,14 @@ def install_logstash():
     ])
 
     ctx.logger.info('Installing PostgreSQL JDBC driver...')
+    jar_path = '/opt/logstash/vendor/jar'
+    jdbc_path = join(jar_path, 'jdbc')
+    utils.mkdir(jdbc_path)
+    utils.chown('logstash', 'logstash', '/opt/logstash/vendor/jar')
     utils.download_file(
         postgresql_jdbc_driver_url,
-        join(
-            '/opt/logstash/vendor/jar/jdbc',
-            basename(postgresql_jdbc_driver_url),
-        ),
+        join(jdbc_path, basename(postgresql_jdbc_driver_url)),
     )
-    utils.chown('logstash', 'logstash', '/opt/logstash/vendor/jar')
 
     ctx.logger.info('Creating PostgreSQL tables...')
     for table_name in ['logs', 'events']:

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -47,7 +47,7 @@ def install_logstash():
     jar_path = '/opt/logstash/vendor/jar'
     jdbc_path = join(jar_path, 'jdbc')
     utils.mkdir(jdbc_path)
-    utils.chown('logstash', 'logstash', '/opt/logstash/vendor/jar')
+    utils.chown('logstash', 'logstash', jar_path)
     utils.download_file(
         postgresql_jdbc_driver_url,
         join(jdbc_path, basename(postgresql_jdbc_driver_url)),

--- a/components/utils.py
+++ b/components/utils.py
@@ -305,14 +305,25 @@ def get_file_content(file_path):
 
 
 def curl_download_with_retries(source, destination):
-    curl_cmd = ['curl']
-    curl_cmd.extend(['--retry', '10'])
-    curl_cmd.append('--fail')
-    curl_cmd.append('--silent')
-    curl_cmd.append('--show-error')
-    curl_cmd.extend(['--location', source])
-    curl_cmd.append('--create-dir')
-    curl_cmd.extend(['--output', destination])
+    """Download file using the curl command.
+
+    :param source: Source URL for the file to download
+    :typ source: str
+    :param destination:
+        Path to the directory where the file should be downloaded
+    :type destination: str
+
+    """
+    curl_cmd = [
+        'curl',
+        '--retry', '10',
+        '--fail',
+        '--silent',
+        '--show-error',
+        '--location', source,
+        '--create-dir',
+        '--output', destination,
+    ]
     ctx.logger.debug('curling: {0}'.format(' '.join(curl_cmd)))
     run(curl_cmd)
 


### PR DESCRIPTION
In this PR, the target directory for the jdbc driver file is created before curl is executed to workaround the permissions error.