### PR TITLE
CFY-6133. Store json data for logs/events in PostgreSQL

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -54,7 +54,15 @@ output {
         jdbc {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
-            statement => [ "INSERT INTO logs (timestamp, message) VALUES(CAST (? AS timestamp), ?)", "@timestamp", "[message][text]" ]
+            statement => [
+              "INSERT INTO logs (timestamp, context, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), CAST (? AS JSONB), ?, ?, CAST (? AS JSONB), ?)",
+              "@timestamp",
+              "%{[context]}",
+              "[logger]",
+              "[level]",
+              "%{[message]}",
+              "[message_code]"
+            ]
         }
     }
 
@@ -62,7 +70,14 @@ output {
         jdbc {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
-            statement => [ "INSERT INTO events (timestamp, message) VALUES(CAST (? AS timestamp), ?)", "@timestamp", "[message][text]" ]
+            statement => [
+              "INSERT INTO events (timestamp, context, event_type, message, message_code) VALUES(CAST (? AS TIMESTAMP), CAST (? AS JSONB), ?, CAST (? AS JSONB), ?)",
+              "@timestamp",
+              "%{[context]}",
+              "[event_type]",
+              "%{[message]}",
+              "[message_code]"
+            ]
         }
     }
 }

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,12 +55,11 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, context, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), CAST (? AS JSONB), ?, ?, CAST (? AS JSONB), ?)",
+              "INSERT INTO logs (timestamp, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, ?)",
               "@timestamp",
-              "%{[context]}",
               "[logger]",
               "[level]",
-              "%{[message]}",
+              "%{[message][text]}",
               "[message_code]"
             ]
         }
@@ -71,11 +70,10 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, context, event_type, message, message_code) VALUES(CAST (? AS TIMESTAMP), CAST (? AS JSONB), ?, CAST (? AS JSONB), ?)",
+              "INSERT INTO events (timestamp, event_type, message, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?)",
               "@timestamp",
-              "%{[context]}",
               "[event_type]",
-              "%{[message]}",
+              "%{[message][text]}",
               "[message_code]"
             ]
         }

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -66,10 +66,9 @@ def create_postgresql_tables():
         (
             'CREATE TABLE {0} ('
             'timestamp TIMESTAMP,'
-            'context JSONB,'
             'logger TEXT,'
             'level TEXT,'
-            'message JSONB,'
+            'message TEXT,'
             'message_code TEXT'
             ');'
             'ALTER TABLE {0} OWNER TO cloudify;'
@@ -83,9 +82,8 @@ def create_postgresql_tables():
         (
             'CREATE TABLE {0} ('
             'timestamp TIMESTAMP,'
-            'context JSONB,'
             'event_type TEXT,'
-            'message JSONB,'
+            'message TEXT,'
             'message_code TEXT'
             ');'
             'ALTER TABLE {0} OWNER TO cloudify;'

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -24,6 +24,7 @@ ctx_properties = utils.ctx_factory.create(LOGSTASH_SERVICE_NAME)
 
 def install_logstash_output_jdbc_plugin():
     """"Install output plugin needed to write to SQL databases."""
+    plugin_url = ctx_properties['logstash_output_jdbc_plugin_url']
     plugin_url = (
         'https://rubygems.org/downloads/logstash-output-jdbc-0.2.10.gem'
     )
@@ -39,9 +40,7 @@ def install_logstash_output_jdbc_plugin():
 
 def install_postgresql_jdbc_driver():
     """Install driver used by the jdbc plugin to write data to postgresql."""
-    driver_url = (
-        'https://jdbc.postgresql.org/download/postgresql-9.4.1212.jar'
-    )
+    driver_url = ctx_properties['postgresql_jdbc_driver_url']
 
     ctx.logger.info('Installing PostgreSQL JDBC driver...')
     jar_path = '/opt/logstash/vendor/jar'

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import tempfile
+
 from os.path import (
     basename,
     dirname,
@@ -28,6 +30,9 @@ def install_logstash():
     postgresql_jdbc_driver_url = (
         'https://jdbc.postgresql.org/download/postgresql-9.4.1212.jar'
     )
+    logstash_output_jdbc_url = (
+        'https://rubygems.org/downloads/logstash-output-jdbc-0.2.10.gem'
+    )
 
     logstash_log_path = '/var/log/cloudify/logstash'
 
@@ -38,9 +43,17 @@ def install_logstash():
     utils.yum_install(logstash_source_url, service_name=LOGSTASH_SERVICE_NAME)
 
     ctx.logger.info('Installing logstash-output-jdbc plugin...')
+    logstash_output_jdbc_path = join(
+        tempfile.gettempdir(),
+        basename(logstash_output_jdbc_url),
+    )
+    utils.download_file(
+        logstash_output_jdbc_url,
+        logstash_output_jdbc_path,
+    )
     utils.run([
         'sudo', '-u', 'logstash',
-        '/opt/logstash/bin/plugin', 'install', 'logstash-output-jdbc',
+        '/opt/logstash/bin/plugin', 'install', logstash_output_jdbc_path,
     ])
 
     ctx.logger.info('Installing PostgreSQL JDBC driver...')

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -196,7 +196,7 @@ inputs:
 
   postgresql_jdbc_driver_url:
     type: string
-    default: postgresql-9.4.1212.jar
+    default: 'https://jdbc.postgresql.org/download/postgresql-9.4.1212.jar'
 
   python_psycopg2_rpm_url:
     type: string
@@ -217,7 +217,7 @@ inputs:
   logstash_output_jdbc_plugin_url:
     description: logstash-output-jdbc-plugin location
     type: string
-    default: logstash-output-jdbc-0.2.10.gem
+    default: 'https://rubygems.org/downloads/logstash-output-jdbc-0.2.10.gem'
 
   nginx_source_url:
     type: string


### PR DESCRIPTION
In this PR, the schema for the `logs` and `events` tables has been updated to include the same fields as seen in the elasticsearch records except for those fields that don't really add any information:
- `tags` is used by logstash to decide in which table to insert each record
- `type` is always set to `cloudify_log` for logs and `cloudify_event` for events

There are still a few fields that don't seem to be used that might be removed in the future:
- `message_code` seems to be always set to `null`
- `message.argument` seems to be always set to `null` (only present for events)

Even, a change in the schema might be useful to display information in a clearer way. For example, using a `message` field directly would make it easier to use instead of having a json object that contains a  `text` field in it and no other field (aside from the `argument` field mentioned above).