### PR TITLE
CFY-6133. PostgreSQL full-text search

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,7 +55,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, to_tsvector('english', ?), ?)",
+              "INSERT INTO logs (timestamp, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
               "@timestamp",
               "[logger]",
               "[level]",
@@ -71,7 +71,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, to_tsvector('english', ?), ?)",
+              "INSERT INTO events (timestamp, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
               "@timestamp",
               "[event_type]",
               "%{[message][text]}",

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,10 +55,11 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, ?)",
+              "INSERT INTO logs (timestamp, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, to_tsvector('english', ?), ?)",
               "@timestamp",
               "[logger]",
               "[level]",
+              "%{[message][text]}",
               "%{[message][text]}",
               "[message_code]"
             ]
@@ -70,9 +71,10 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, event_type, message, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?)",
+              "INSERT INTO events (timestamp, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, to_tsvector('english', ?), ?)",
               "@timestamp",
               "[event_type]",
+              "%{[message][text]}",
               "%{[message][text]}",
               "[message_code]"
             ]

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -69,8 +69,11 @@ def create_postgresql_tables():
             'logger TEXT,'
             'level TEXT,'
             'message TEXT,'
+            'message_vector TSVECTOR,'
             'message_code TEXT'
             ');'
+            'CREATE INDEX {0}_message_vector_idx '
+            'ON {0} USING GIN (message_vector);'
             'ALTER TABLE {0} OWNER TO cloudify;'
             .format('logs')
         )
@@ -84,8 +87,11 @@ def create_postgresql_tables():
             'timestamp TIMESTAMP,'
             'event_type TEXT,'
             'message TEXT,'
+            'message_vector TSVECTOR,'
             'message_code TEXT'
             ');'
+            'CREATE INDEX {0}_message_vector_idx '
+            'ON {0} USING GIN (message_vector);'
             'ALTER TABLE {0} OWNER TO cloudify;'
             .format('events')
         )


### PR DESCRIPTION
In this PR:
- a new column named `message_vector` of type `tsvector` is added to the `logs` and `events` tables to store the parsed version of the message
- an index on that `message_vector` column is created

After these changes, full-text search queries against the `logs` and `events` tables can be executed efficiently. For example: `SELECT message FROM logs WHERE message_vector @@ to_tsquery('server')`.

Note that, after the bootstrap process, some messages contains fragments surrounded by `<`  and `>` signs such as:
`Applying function:setter on Attribute <file_server_port>`

The problem with those fragments is that the parser confuses them with XML tags and discards them. To include them in the vector, the `translate` function is used to drop the `<` and `>` characters as suggested in this [dba stackexchange question](http://dba.stackexchange.com/q/129413/111284).

```
cloudify_db=# SELECT message, message_vector FROM logs LIMIT 1;
                         message                          |                               message_vector                                
----------------------------------------------------------+-----------------------------------------------------------------------------
 Applying function:setter on Attribute <file_server_port> | 'appli':1 'attribut':5 'file':6 'function':2 'port':8 'server':7 'setter':3
(1 row)
```