### PR TITLE
CFY-6091. Create log tables in rest service

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,8 +55,9 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
+              "INSERT INTO logs (timestamp, execution_fk, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
               "@timestamp",
+              "%{[context][execution_id]}",
               "[logger]",
               "[level]",
               "%{[message][text]}",
@@ -71,8 +72,9 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
+              "INSERT INTO events (timestamp, execution_fk, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
               "@timestamp",
+              "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",
               "%{[message][text]}",

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,12 +55,11 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, execution_fk, logger, level, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
+              "INSERT INTO logs (timestamp, execution_fk, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[logger]",
               "[level]",
-              "%{[message][text]}",
               "%{[message][text]}",
               "[message_code]"
             ]
@@ -72,11 +71,10 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, execution_fk, event_type, message, message_vector, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, to_tsvector('english', translate(?, '<>', '')), ?)",
+              "INSERT INTO events (timestamp, execution_fk, event_type, message,  message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",
-              "%{[message][text]}",
               "%{[message][text]}",
               "[message_code]"
             ]

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -56,48 +56,6 @@ def install_postgresql_jdbc_driver():
     ])
 
 
-def create_postgresql_tables():
-    """Create database tables to store log/event information."""
-    ctx.logger.info('Creating PostgreSQL tables...')
-
-    utils.run([
-        'sudo', '-u', 'postgres',
-        'psql', 'cloudify_db', '-c',
-        (
-            'CREATE TABLE {0} ('
-            'timestamp TIMESTAMP,'
-            'logger TEXT,'
-            'level TEXT,'
-            'message TEXT,'
-            'message_vector TSVECTOR,'
-            'message_code TEXT'
-            ');'
-            'CREATE INDEX {0}_message_vector_idx '
-            'ON {0} USING GIN (message_vector);'
-            'ALTER TABLE {0} OWNER TO cloudify;'
-            .format('logs')
-        )
-    ])
-
-    utils.run([
-        'sudo', '-u', 'postgres',
-        'psql', 'cloudify_db', '-c',
-        (
-            'CREATE TABLE {0} ('
-            'timestamp TIMESTAMP,'
-            'event_type TEXT,'
-            'message TEXT,'
-            'message_vector TSVECTOR,'
-            'message_code TEXT'
-            ');'
-            'CREATE INDEX {0}_message_vector_idx '
-            'ON {0} USING GIN (message_vector);'
-            'ALTER TABLE {0} OWNER TO cloudify;'
-            .format('events')
-        )
-    ])
-
-
 def install_logstash():
     """Install logstash as a systemd service."""
     logstash_unit_override = '/etc/systemd/system/logstash.service.d'
@@ -113,7 +71,6 @@ def install_logstash():
 
     install_logstash_output_jdbc_plugin()
     install_postgresql_jdbc_driver()
-    create_postgresql_tables()
 
     utils.mkdir(logstash_log_path)
     utils.chown('logstash', 'logstash', logstash_log_path)


### PR DESCRIPTION
In this PR, the code that creates the `logs` and `events` tables is removed since those tables will be created based on a model defined in the rest service code.

Related: cloudify-cosmo/cloudify-manager#638