### PR TITLE
CFY-6161 set an upper bound limit (12) for gunicorn number of workers

### DIFF
--- a/aws-ec2-manager-blueprint-inputs.yaml
+++ b/aws-ec2-manager-blueprint-inputs.yaml
@@ -312,7 +312,7 @@ aws_secret_access_key: ''
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then  min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 

--- a/azure-manager-blueprint-inputs.yaml
+++ b/azure-manager-blueprint-inputs.yaml
@@ -289,7 +289,7 @@ retry_after: 30
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 

--- a/components/restservice/config/cloudify-restservice
+++ b/components/restservice/config/cloudify-restservice
@@ -16,3 +16,7 @@ REST_SERVICE_LOG_PATH="/var/log/cloudify/rest"
 
 # REST Service port
 REST_PORT=8100
+
+# gunicorn configuration
+WORKER_COUNT=$(($(nproc) * 2 + 1))
+MAX_WORKER_COUNT=12

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -9,7 +9,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /var/run/gunicorn.pid \
-    -w {{ node.properties.gunicorn_worker_count or '$(($(nproc)*2+1))' }} \
+    -w {{ node.properties.gunicorn_worker_count or '$((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT}))' }} \
     -b 0.0.0.0:${REST_PORT} \
     --timeout 300 manager_rest.server:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -41,7 +41,7 @@ inputs:
   rest_service_gunicorn_worker_count:
     description: |
       The number of worker processes for handling requests.
-      If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
     type: integer
     default: 0
 

--- a/openstack-manager-blueprint-inputs.yaml
+++ b/openstack-manager-blueprint-inputs.yaml
@@ -320,7 +320,7 @@ external_network_name: ''
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 

--- a/simple-manager-blueprint-inputs.yaml
+++ b/simple-manager-blueprint-inputs.yaml
@@ -281,7 +281,7 @@
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 

--- a/tests/unit-tests/test_restservice.py
+++ b/tests/unit-tests/test_restservice.py
@@ -34,7 +34,7 @@ class TestRestServiceFile(TestCase):
                 'gunicorn_worker_count': 0,
             },
         })
-        self.assertThat(text, Contains('-w $(($(nproc)*2+1)) \\'))
+        self.assertThat(text, Contains('-w $((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT})) \\'))  # NOQA
 
     def test_render_integer(self):
         """Render template using an integer as the worker count."""

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -748,7 +748,7 @@ node_types:
       gunicorn_worker_count:
         description: |
           The number of worker processes for handling requests.
-          If value is set to 0, then (2 * cpu_count + 1 processes) will be used.
+          If value is set to 0, then min((2 * cpu_count + 1 processes), 12) will be used.
         type: integer
         default: { get_input: rest_service_gunicorn_worker_count }
     interfaces:

--- a/vcloud-manager-blueprint-inputs.yaml
+++ b/vcloud-manager-blueprint-inputs.yaml
@@ -349,7 +349,7 @@ user_public_key: ssh-rsa...
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 

--- a/vsphere-manager-blueprint-inputs.yaml
+++ b/vsphere-manager-blueprint-inputs.yaml
@@ -348,7 +348,7 @@
 #rest_service_gunicorn_worker_count:
 #  description: |
 #    The number of worker processes for handling requests.
-#    If the default value (0) is set, then (2 * cpu_count + 1 processes) will be used.
+#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #  type: integer
 #  default: 0
 


### PR DESCRIPTION
The default number of gunicorn workers (cpus*2 + 1) should have an upper bound limit as in VMs with many CPUs this can turn to a memory issue and probably not necessary to have that many gunicorn workers.
In this PR, the number of gunicorn workers is limited to 12.
The ability to configure the number of workers is preserved.