### PR TITLE
CFY-6161 make number of gunicorn workers configurable and limited to 12

### DIFF
--- a/aws-ec2-manager-blueprint-inputs.yaml
+++ b/aws-ec2-manager-blueprint-inputs.yaml
@@ -276,6 +276,10 @@ aws_secret_access_key: ''
 # Minimum number of worker processes maintained by the management worker.
 #management_worker_min_workers: 2
 
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -436,6 +436,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:

--- a/azure-manager-blueprint.yaml
+++ b/azure-manager-blueprint.yaml
@@ -495,6 +495,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:

--- a/components/restservice/config/cloudify-restservice
+++ b/components/restservice/config/cloudify-restservice
@@ -16,3 +16,7 @@ REST_SERVICE_LOG_PATH="/var/log/cloudify/rest"
 
 # REST Service port
 REST_SERVICE_PORT=8100
+
+# gunicorn configuration
+WORKER_COUNT=$(($(nproc) * 2 + 1))
+MAX_WORKER_COUNT=12

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -10,7 +10,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /var/run/gunicorn.pid \
-    -w $(($(nproc)*2+1)) \
+    -w {{ node.properties.gunicorn_worker_count or '$((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT}))' }} \
     -b 0.0.0.0:${REST_SERVICE_PORT} \
     --timeout 300 manager_rest.server:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \

--- a/components/restservice/scripts/preconfigure.py
+++ b/components/restservice/scripts/preconfigure.py
@@ -26,7 +26,7 @@ def preconfigure_restservice():
         f.write(sec_config)
     utils.move(path, os.path.join(rest_service_home, 'rest-security.conf'))
 
-    utils.systemd.configure(REST_SERVICE_NAME, render=False)
+    utils.systemd.configure(REST_SERVICE_NAME)
 
 
 preconfigure_restservice()

--- a/openstack-manager-blueprint-inputs.yaml
+++ b/openstack-manager-blueprint-inputs.yaml
@@ -284,6 +284,10 @@ agents_user: ''
 # Minimum number of worker processes maintained by the management worker.
 #management_worker_min_workers: 2
 
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -474,6 +474,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:

--- a/simple-manager-blueprint-inputs.yaml
+++ b/simple-manager-blueprint-inputs.yaml
@@ -245,6 +245,10 @@ agents_user: ''
 # Minimum number of worker processes maintained by the management worker.
 #management_worker_min_workers: 2
 
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -384,6 +384,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:

--- a/tests/unit-tests/test_restservice.py
+++ b/tests/unit-tests/test_restservice.py
@@ -1,0 +1,50 @@
+import os
+
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+)
+from testtools import TestCase
+from testtools.matchers import Contains
+
+
+class TestRestServiceFile(TestCase):
+
+    """Test service file."""
+
+    TEMPLATE_DIR = os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        'components',
+        'restservice',
+        'config',
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        """Get template object."""
+        env = Environment(loader=FileSystemLoader(cls.TEMPLATE_DIR))
+        cls.template = env.get_template('cloudify-restservice.service')
+
+    def test_render_default(self):
+        """Render template using 0 as the worker count."""
+        text = self.template.render(node={
+            'properties': {
+                'gunicorn_worker_count': 0,
+            },
+        })
+        self.assertThat(text, Contains('-w $((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT})) \\'))  # NOQA
+
+    def test_render_integer(self):
+        """Render template using an integer as the worker count."""
+        expected_worker_count = 12345
+        text = self.template.render(node={
+            'properties': {
+                'gunicorn_worker_count': expected_worker_count,
+            },
+        })
+        self.assertThat(
+            text,
+            Contains('-w {0} \\'.format(expected_worker_count)),
+        )

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -663,6 +663,12 @@ node_types:
         description: Use existing elasticsearch configuration
         type: string
         default: true
+      gunicorn_worker_count:
+        description: |
+          The number of worker processes for handling requests.
+          If value is set to 0, then min((2 * cpu_count + 1 processes)) will be used.
+        type: integer
+        default: { get_input: rest_service_gunicorn_worker_count }
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/vcloud-manager-blueprint-inputs.yaml
+++ b/vcloud-manager-blueprint-inputs.yaml
@@ -308,6 +308,10 @@ user_public_key: ssh-rsa...
 # Minimum number of worker processes maintained by the management worker.
 #management_worker_min_workers: 2
 
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/vcloud-manager-blueprint.yaml
+++ b/vcloud-manager-blueprint.yaml
@@ -553,6 +553,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:

--- a/vsphere-manager-blueprint-inputs.yaml
+++ b/vsphere-manager-blueprint-inputs.yaml
@@ -311,6 +311,10 @@
 # Minimum number of worker processes maintained by the management worker.
 #management_worker_min_workers: 2
 
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
 #############################
 # Offline Resources Upload
 #############################

--- a/vsphere-manager-blueprint.yaml
+++ b/vsphere-manager-blueprint.yaml
@@ -560,6 +560,16 @@ inputs:
     default: 54329
 
   #############################
+  # REST Configuration
+  #############################
+  rest_service_gunicorn_worker_count:
+    description: |
+      The number of worker processes for handling requests.
+      If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+    type: integer
+    default: 0
+
+  #############################
   # InfluxDB Inputs
   #############################
   influxdb_endpoint_ip:


### PR DESCRIPTION
This PR is for 3.4.1:
1. Configurable gunicorn worker count.
2. Upper bound limit (12) if gunicorn worker count is auto calculated.