### PR TITLE
CFY-6163 set gunicorn max requests to 1000 and make it configurable

### DIFF
--- a/aws-ec2-manager-blueprint-inputs.yaml
+++ b/aws-ec2-manager-blueprint-inputs.yaml
@@ -280,6 +280,10 @@ aws_secret_access_key: ''
 # If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #rest_service_gunicorn_worker_count: 0
 
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
+
 #############################
 # Offline Resources Upload
 #############################

--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -445,6 +445,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################

--- a/azure-manager-blueprint.yaml
+++ b/azure-manager-blueprint.yaml
@@ -504,6 +504,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -11,6 +11,7 @@ EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /var/run/gunicorn.pid \
     -w {{ node.properties.gunicorn_worker_count or '$((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT}))' }} \
+    --max-requests {{ node.properties.gunicorn_max_requests }} \
     -b 0.0.0.0:${REST_SERVICE_PORT} \
     --timeout 300 manager_rest.server:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \

--- a/openstack-manager-blueprint-inputs.yaml
+++ b/openstack-manager-blueprint-inputs.yaml
@@ -288,6 +288,10 @@ agents_user: ''
 # If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #rest_service_gunicorn_worker_count: 0
 
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
+
 #############################
 # Offline Resources Upload
 #############################

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -483,6 +483,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################

--- a/simple-manager-blueprint-inputs.yaml
+++ b/simple-manager-blueprint-inputs.yaml
@@ -249,6 +249,10 @@ agents_user: ''
 # If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #rest_service_gunicorn_worker_count: 0
 
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
+
 #############################
 # Offline Resources Upload
 #############################

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -393,6 +393,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################

--- a/tests/unit-tests/test_restservice.py
+++ b/tests/unit-tests/test_restservice.py
@@ -32,9 +32,11 @@ class TestRestServiceFile(TestCase):
         text = self.template.render(node={
             'properties': {
                 'gunicorn_worker_count': 0,
+                'gunicorn_max_requests': 1000
             },
         })
         self.assertThat(text, Contains('-w $((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT})) \\'))  # NOQA
+        self.assertThat(text, Contains('--max-requests 1000'))
 
     def test_render_integer(self):
         """Render template using an integer as the worker count."""

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -669,6 +669,13 @@ node_types:
           If value is set to 0, then min((2 * cpu_count + 1 processes)) will be used.
         type: integer
         default: { get_input: rest_service_gunicorn_worker_count }
+      gunicorn_max_requests:
+        description: |
+          The maximum number of requests a worker will process before restarting.
+          If this is set to zero then the automatic worker restarts are disabled.
+        type: integer
+        default: { get_input: rest_service_gunicorn_max_requests }
+
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/vcloud-manager-blueprint-inputs.yaml
+++ b/vcloud-manager-blueprint-inputs.yaml
@@ -312,6 +312,10 @@ user_public_key: ssh-rsa...
 # If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #rest_service_gunicorn_worker_count: 0
 
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
+
 #############################
 # Offline Resources Upload
 #############################

--- a/vcloud-manager-blueprint.yaml
+++ b/vcloud-manager-blueprint.yaml
@@ -562,6 +562,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################

--- a/vsphere-manager-blueprint-inputs.yaml
+++ b/vsphere-manager-blueprint-inputs.yaml
@@ -315,6 +315,10 @@
 # If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
 #rest_service_gunicorn_worker_count: 0
 
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
+
 #############################
 # Offline Resources Upload
 #############################

--- a/vsphere-manager-blueprint.yaml
+++ b/vsphere-manager-blueprint.yaml
@@ -569,6 +569,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # InfluxDB Inputs
   #############################


### PR DESCRIPTION
In this PR an input is added for setting gunicorn max requests setting where the default value is 1000.
