### PR TITLE
CFY-6163 gunicorn max requests = 1000 and configurable

### DIFF
--- a/aws-ec2-manager-blueprint-inputs.yaml
+++ b/aws-ec2-manager-blueprint-inputs.yaml
@@ -309,12 +309,13 @@ aws_secret_access_key: ''
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
-#rest_service_gunicorn_worker_count:
-#  description: |
-#    The number of worker processes for handling requests.
-#    If the default value (0) is set, then  min((2 * cpu_count + 1 processes), 12) will be used.
-#  type: integer
-#  default: 0
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
 
 #############################
 # Offline Resources Upload

--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /var/run/gunicorn.pid \
     -w {{ node.properties.gunicorn_worker_count or '$((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT}))' }} \
+    --max-requests {{ node.properties.gunicorn_max_requests }} \
     -b 0.0.0.0:${REST_PORT} \
     --timeout 300 manager_rest.server:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -45,6 +45,13 @@ inputs:
     type: integer
     default: 0
 
+  rest_service_gunicorn_max_requests:
+    description: |
+      The maximum number of requests a worker will process before restarting.
+      If this is set to zero then the automatic worker restarts are disabled.
+    type: integer
+    default: 1000
+
   #############################
   # Bootstrap Validations
   #############################

--- a/openstack-manager-blueprint-inputs.yaml
+++ b/openstack-manager-blueprint-inputs.yaml
@@ -317,12 +317,13 @@ external_network_name: ''
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
-#rest_service_gunicorn_worker_count:
-#  description: |
-#    The number of worker processes for handling requests.
-#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
-#  type: integer
-#  default: 0
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
 
 #############################
 # Offline Resources Upload

--- a/simple-manager-blueprint-inputs.yaml
+++ b/simple-manager-blueprint-inputs.yaml
@@ -278,12 +278,13 @@
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
-#rest_service_gunicorn_worker_count:
-#  description: |
-#    The number of worker processes for handling requests.
-#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
-#  type: integer
-#  default: 0
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
 
 #############################
 # Offline Resources Upload

--- a/tests/unit-tests/test_restservice.py
+++ b/tests/unit-tests/test_restservice.py
@@ -32,9 +32,11 @@ class TestRestServiceFile(TestCase):
         text = self.template.render(node={
             'properties': {
                 'gunicorn_worker_count': 0,
+                'gunicorn_max_requests': 1000,
             },
         })
         self.assertThat(text, Contains('-w $((${WORKER_COUNT} > ${MAX_WORKER_COUNT} ? ${MAX_WORKER_COUNT} : ${WORKER_COUNT})) \\'))  # NOQA
+        self.assertThat(text, Contains('--max-requests 1000'))
 
     def test_render_integer(self):
         """Render template using an integer as the worker count."""

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -751,6 +751,12 @@ node_types:
           If value is set to 0, then min((2 * cpu_count + 1 processes), 12) will be used.
         type: integer
         default: { get_input: rest_service_gunicorn_worker_count }
+      gunicorn_max_requests:
+        description: |
+          The maximum number of requests a worker will process before restarting.
+          If this is set to zero then the automatic worker restarts are disabled.
+        type: integer
+        default: { get_input: rest_service_gunicorn_max_requests }
     interfaces:
       cloudify.interfaces.lifecycle:
         create:

--- a/vcloud-manager-blueprint-inputs.yaml
+++ b/vcloud-manager-blueprint-inputs.yaml
@@ -346,12 +346,13 @@ user_public_key: ssh-rsa...
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
 
-#rest_service_gunicorn_worker_count:
-#  description: |
-#    The number of worker processes for handling requests.
-#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
-#  type: integer
-#  default: 0
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
 
 #############################
 # Offline Resources Upload

--- a/vsphere-manager-blueprint-inputs.yaml
+++ b/vsphere-manager-blueprint-inputs.yaml
@@ -344,13 +344,14 @@
 
 # valid values: public_ip, private_ip
 #rest_host_internal_endpoint_type: private_ip
-#
-#rest_service_gunicorn_worker_count:
-#  description: |
-#    The number of worker processes for handling requests.
-#    If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
-#  type: integer
-#  default: 0
+
+# The number of gunicorn worker processes for handling requests.
+# If the default value (0) is set, then min((2 * cpu_count + 1 processes), 12) will be used.
+#rest_service_gunicorn_worker_count: 0
+
+# The maximum number of requests a worker will process before restarting.
+# If this is set to zero then the automatic worker restarts are disabled.
+#rest_service_gunicorn_max_requests: 1000
 
 #############################
 # Offline Resources Upload


### PR DESCRIPTION
In this PR, gunicorn max requests is set to 1000 and is configurable using an input.
In addition, the gunicorn worker count input format has been adjusted as it was in TOSCA format while inputs are just yaml files with keys and values.