### PR TITLE
CFY-6091. Insert deployment reference in both logs and events

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,8 +55,9 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, execution_fk, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
+              "INSERT INTO logs (timestamp, deployment_fk, execution_fk, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM deployments WHERE id = ?), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
               "@timestamp",
+              "%{[context][deployment_id]}",
               "%{[context][execution_id]}",
               "[logger]",
               "[level]",
@@ -71,8 +72,9 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, execution_fk, event_type, message,  message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?)",
+              "INSERT INTO events (timestamp, deployment_fk, execution_fk, event_type, message,  message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT storage_id FROM deployments WHERE id = ?), (SELECT storage_id FROM executions WHERE id = ?), ?, ?, ?)",
               "@timestamp",
+              "%{[context][deployment_id]}",
               "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",


### PR DESCRIPTION
In this PR, a reference to the deployment is added to both the events and the logs tables since that information needs to be included in the response from the API.

Related: cloudify-cosmo/cloudify-manager#656