### PR TITLE
CFY-6091 Fix sanity check by updating parameters in event URL

### DIFF
--- a/components/manager/scripts/sanity/sanity.py
+++ b/components/manager/scripts/sanity/sanity.py
@@ -120,9 +120,14 @@ def _install_sanity_app():
 
 def _assert_logs_and_events(execution_id):
     headers = utils.create_maintenance_headers()
-    params = urllib.urlencode(
-            dict(execution_id=execution_id,
-                 type='cloudify_log'))
+    params = urllib.urlencode((
+        ('execution_id', execution_id),
+        ('type', 'cloudify_event'),
+        ('type', 'cloudify_log'),
+        ('_sort', '@timestamp'),
+        ('_size', 100),
+        ('_offset', 0),
+    ))
 
     endpoint = '{0}/events'.format(_get_url_prefix())
     url = endpoint + '?' + params


### PR DESCRIPTION
The latest update in the restservice is more restrictive in terms of parameters that are needed. In this change, the parameters that are missing have been added.

Note: this is just a quick fix, better validation should be implemented in the rest service method in the future.