### PR TITLE
CFY-6317 Protect default tenant

### DIFF
--- a/components/restservice/config/cloudify-rest.conf
+++ b/components/restservice/config/cloudify-rest.conf
@@ -10,7 +10,6 @@
     postgresql_host: '{{ ctx.instance.runtime_properties.postgresql_host }}',
     postgresql_username: 'cloudify',
     postgresql_password: 'cloudify',
-    default_tenant_name: 'default_tenant',
     ldap_server: '{{ ctx.instance.runtime_properties.ldap_server }}',
     ldap_username: '{{ ctx.instance.runtime_properties.ldap_username }}',
     ldap_password: '{{ ctx.instance.runtime_properties.ldap_password }}',


### PR DESCRIPTION
 - Make the default tenant ID constant (set to 0)
 - Prevent deletion of the default tenant
 - Streamline the creation of the default tenant
 - Make more use of the default tenant constants (instead of strings)