### PR TITLE
CFY 6090. Add missing columns to events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - 2.7
 
 install:
-    - pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0m11.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/4.0m11.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0m11.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0m13.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/4.0m13.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0m13.zip
     - pip install https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/4.0m11.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/4.0m13.zip
     - pip install https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/1.3.1.zip
     - pip install coverage==3.7.1
     - pip install nose

--- a/circle.yml
+++ b/circle.yml
@@ -13,11 +13,11 @@ checkout:
 dependencies:
   override:
     - pip install pytz
-    - pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0m11.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/4.0m11.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0m11.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0m13.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/4.0m13.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0m13.zip
     - pip install https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.zip
-    - pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/4.0m11.zip
+    - pip install https://github.com/cloudify-cosmo/cloudify-cli/archive/4.0m13.zip
     - pip install https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/1.3.1.zip
     - pip install coverage==3.7.1
     - pip install nose

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -64,14 +64,15 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?)",
+              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[logger]",
               "[level]",
               "%{[message][text]}",
               "[message_code]",
-              "%{[context][operation]}"
+              "%{[context][operation]}",
+              "%{[context][node_id]}"
             ]
         }
     }
@@ -81,13 +82,14 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
+              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",
               "[message_code]",
-              "%{[context][operation]}"
+              "%{[context][operation]}",
+              "%{[context][node_id]}"
             ]
         }
     }

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -42,6 +42,7 @@ filter {
     date { match => [ "timestamp", "ISO8601" ] }
 
     # Set context.operation field to the empty string by default
+    # this will be inserted as null below thanks to NULLIF
     if ![context][operation] {
         mutate {
             add_field => {
@@ -51,6 +52,7 @@ filter {
     }
 
     # Set context.node_id field to the empty string by default
+    # this will be inserted as null below thanks to NULLIF
     if ![context][node_id] {
         mutate {
             add_field => {
@@ -73,7 +75,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?, ?)",
+              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
               "%{[context][execution_id]}",
               "[logger]",
@@ -91,7 +93,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?)",
+              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -49,6 +49,15 @@ filter {
             }
         }
     }
+
+    # Set context.node_id field to the empty string by default
+    if ![context][node_id] {
+        mutate {
+            add_field => {
+                "[context][node_id]" => ""
+            }
+        }
+    }
 }
 
 

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -55,13 +55,14 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
+              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[logger]",
               "[level]",
               "%{[message][text]}",
-              "[message_code]"
+              "[message_code]",
+              "%{[context][operation]}"
             ]
         }
     }
@@ -71,12 +72,13 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?)",
+              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?)",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",
-              "[message_code]"
+              "[message_code]",
+              "%{[context][operation]}"
             ]
         }
     }

--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -40,6 +40,15 @@ input {
 # It is only a temporary solution.
 filter {
     date { match => [ "timestamp", "ISO8601" ] }
+
+    # Set context.operation field to the empty string by default
+    if ![context][operation] {
+        mutate {
+            add_field => {
+                "[context][operation]" => ""
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
In this PR, logstash configuration is updated to insert `node_id` and `operation` values into the `events`/`logs` tables in the database. If any of these values is missing then `NULL` is inserted instead.

Requires: cloudify-cosmo/cloudify-manager#699