### PR TITLE
CFY-6373 Security groups: allow world access to cluster ports

### DIFF
--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -279,23 +279,23 @@ node_templates:
         - ip_protocol: tcp
           from_port: 8300
           to_port: 8300
-          src_group_id: { get_property: [agents_security_group, resource_id] }
+          cidr_ip: 0.0.0.0/0
         - ip_protocol: tcp
           from_port: 8301
           to_port: 8301
-          src_group_id: { get_property: [agents_security_group, resource_id] }
+          cidr_ip: 0.0.0.0/0
         - ip_protocol: tcp
           from_port: 8500
           to_port: 8500
-          src_group_id: { get_property: [agents_security_group, resource_id] }
+          cidr_ip: 0.0.0.0/0
         - ip_protocol: tcp
           from_port: 22000
           to_port: 22000
-          src_group_id: { get_property: [agents_security_group, resource_id] }
+          cidr_ip: 0.0.0.0/0
         - ip_protocol: tcp
           from_port: 15432
           to_port: 15432
-          src_group_id: { get_property: [agents_security_group, resource_id] }
+          cidr_ip: 0.0.0.0/0
       aws_config: *aws_configuration
     relationships:
       - type: cloudify.relationships.depends_on

--- a/azure-manager-blueprint.yaml
+++ b/azure-manager-blueprint.yaml
@@ -422,7 +422,7 @@ node_templates:
             protocol: Tcp
             sourcePortRange: '*'
             destinationPortRange: 8300
-            sourceAddressPrefix: { get_input: subnet_private_cidr }
+            sourceAddressPrefix: '*'
             destinationAddressPrefix: '*'
             priority: 600
             access: Allow
@@ -433,7 +433,7 @@ node_templates:
             protocol: Tcp
             sourcePortRange: '*'
             destinationPortRange: 8301
-            sourceAddressPrefix: { get_input: subnet_private_cidr }
+            sourceAddressPrefix: '*'
             destinationAddressPrefix: '*'
             priority: 601
             access: Allow
@@ -444,7 +444,7 @@ node_templates:
             protocol: Tcp
             sourcePortRange: '*'
             destinationPortRange: 8500
-            sourceAddressPrefix: { get_input: subnet_private_cidr }
+            sourceAddressPrefix: '*'
             destinationAddressPrefix: '*'
             priority: 602
             access: Allow
@@ -455,7 +455,7 @@ node_templates:
             protocol: Tcp
             sourcePortRange: '*'
             destinationPortRange: 22000
-            sourceAddressPrefix: { get_input: subnet_private_cidr }
+            sourceAddressPrefix: '*'
             destinationAddressPrefix: '*'
             priority: 603
             access: Allow
@@ -466,7 +466,7 @@ node_templates:
             protocol: Tcp
             sourcePortRange: '*'
             destinationPortRange: 15432
-            sourceAddressPrefix: { get_input: subnet_private_cidr }
+            sourceAddressPrefix: '*'
             destinationAddressPrefix: '*'
             priority: 604
             access: Allow

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -379,15 +379,15 @@ node_templates:
           remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
         # Cluster-related ports, only used in a manager cluster
         - port: 8300
-          remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
+          remote_ip_prefix: 0.0.0.0/0
         - port: 8301
-          remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
+          remote_ip_prefix: 0.0.0.0/0
         - port: 8500
-          remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
+          remote_ip_prefix: 0.0.0.0/0
         - port: 22000
-          remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
+          remote_ip_prefix: 0.0.0.0/0
         - port: 15432
-          remote_ip_prefix: { get_property: [management_subnet, subnet, cidr] }
+          remote_ip_prefix: 0.0.0.0/0
       openstack_config: *openstack_configuration
 
   manager_server_ip:


### PR DESCRIPTION
We can't guarantee a private network between all cluster nodes
currently - allow 0.0.0.0/0 access to them.