### PR TITLE
Add the / vhost to rabbitmq definitions.json

### DIFF
--- a/components/rabbitmq/config/rabbitmq-definitions.json
+++ b/components/rabbitmq/config/rabbitmq-definitions.json
@@ -18,5 +18,10 @@
       "internal": false,
       "arguments": {}
     }
+  ],
+  "vhosts": [
+    {
+      "name": "/"
+    }
   ]
 }


### PR DESCRIPTION
All our exchanges require that vhost; make sure it is created
always when the exchanges are created, by declaring it in the
definitions file that declares the exchanges.

In normal operation, the / vhost is created when installing
rabbitmq, but it can sometimes be deleted (eg. when resetting
rabbitmq's storage); after that, the exchanges were created as in
the definitions file, but the vhost had to be created by hand.