### PR TITLE
CFY-6497 generate internal SSL certificates on boot

### DIFF
--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -3,8 +3,8 @@
 # /opt/cfy/embedded/bin/python in order to properly load the manager
 # blueprints utils.py module.
 
-import logging
 import imp
+import logging
 import sys
 
 
@@ -15,11 +15,13 @@ class CtxWithLogger(object):
     logger = logging.getLogger('internal-ssl-certs-logger')
 
 
+utils = imp.load_source('utils', UTILS_MODULE_PATH)
+utils.ctx = CtxWithLogger()
+
+
 if __name__ == '__main__':
     if len(sys.argv) != 2:
         print('Expected 1 argument - <manager-ip>')
         print('Provided args: {0}'.format(sys.argv[1:]))
         sys.exit(1)
-    utils = imp.load_source('utils', UTILS_MODULE_PATH)
-    utils.ctx = CtxWithLogger()
     utils.generate_internal_ssl_cert(sys.argv[1])

--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -1,0 +1,25 @@
+
+# This script has to run using the Python executable found in:
+# /opt/cfy/embedded/bin/python in order to properly load the manager
+# blueprints utils.py module.
+
+import logging
+import imp
+import sys
+
+
+UTILS_MODULE_PATH = '/opt/cfy/cloudify-manager-blueprints/components/utils.py'
+
+
+class CtxWithLogger(object):
+    logger = logging.getLogger('internal-ssl-certs-logger')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Expected 1 argument - <manager-ip>')
+        print('Provided args: {0}'.format(sys.argv[1:]))
+        sys.exit(1)
+    utils = imp.load_source('utils', UTILS_MODULE_PATH)
+    utils.ctx = CtxWithLogger()
+    utils.generate_internal_ssl_cert(sys.argv[1])

--- a/components/manager-ip-setter/scripts/create.py
+++ b/components/manager-ip-setter/scripts/create.py
@@ -18,6 +18,7 @@ ctx_properties = utils.ctx_factory.create(MANAGER_IP_SETTER_SERVICE_NAME)
 
 MANAGER_IP_SETTER_SCRIPT_NAME = 'manager-ip-setter.sh'
 UPDATE_PROVIDER_CONTEXT_SCRIPT_NAME = 'update-provider-context.py'
+CREATE_INTERNAL_SSL_CERTS_SCRIPT_NAME = 'create-internal-ssl-certs.py'
 
 MANAGER_IP_SETTER_DIR = '/opt/cloudify/manager-ip-setter'
 
@@ -37,6 +38,7 @@ def install_manager_ip_setter():
     utils.mkdir(dirname(MANAGER_IP_SETTER_DIR))
     deploy_script(MANAGER_IP_SETTER_SCRIPT_NAME)
     deploy_script(UPDATE_PROVIDER_CONTEXT_SCRIPT_NAME)
+    deploy_script(CREATE_INTERNAL_SSL_CERTS_SCRIPT_NAME)
 
 
 if os.environ.get('set_manager_ip_on_boot').lower() == 'true':

--- a/components/manager-ip-setter/scripts/manager-ip-setter.sh
+++ b/components/manager-ip-setter/scripts/manager-ip-setter.sh
@@ -29,8 +29,9 @@ function set_manager_ip() {
   /opt/cloudify/manager-ip-setter/update-provider-context.py ${ip}
 
   echo "Creating internal SSL certificates.."
-  rm -f /etc/cloudify/ssl/cloudify_internal_*.pem
   /opt/cfy/embedded/bin/python /opt/cloudify/manager-ip-setter/create-internal-ssl-certs.py ${ip}
+  
+  echo "Restarting nginx.."
   systemctl restart nginx
 
   echo "Done!"

--- a/components/manager-ip-setter/scripts/manager-ip-setter.sh
+++ b/components/manager-ip-setter/scripts/manager-ip-setter.sh
@@ -28,6 +28,11 @@ function set_manager_ip() {
   echo "Updating broker_ip in provider context.."
   /opt/cloudify/manager-ip-setter/update-provider-context.py ${ip}
 
+  echo "Creating internal SSL certificates.."
+  rm -f /etc/cloudify/ssl/cloudify_internal_*.pem
+  /opt/cfy/embedded/bin/python /opt/cloudify/manager-ip-setter/create-internal-ssl-certs.py ${ip}
+  systemctl restart nginx
+
   echo "Done!"
 
 }

--- a/components/nginx/config/https-internal-rest-server.cloudify
+++ b/components/nginx/config/https-internal-rest-server.cloudify
@@ -2,7 +2,7 @@
 server {
   # server listening for internal requests
   listen              {{ ctx.target.instance.runtime_properties.internal_rest_port }} ssl default_server;
-  server_name         {{ ctx.target.instance.runtime_properties.internal_rest_host }};
+  server_name         _;
 
   ssl_certificate     {{ ctx.source.instance.runtime_properties.internal_cert_path }};
   ssl_certificate_key {{ ctx.source.instance.runtime_properties.internal_key_path }};


### PR DESCRIPTION
In this PR, the manager-ip-setter service is updated to generate the internal SSL certificates when booting the manager from an image.
In order to achieve that, the utils.generate_internal_ssl_cert function is used.
