### PR TITLE
Use localhost as the rabbitmq address in REST service config

### DIFF
--- a/components/restservice/config/cloudify-rest.conf
+++ b/components/restservice/config/cloudify-rest.conf
@@ -14,7 +14,7 @@
     ldap_domain: '{{ ctx.instance.runtime_properties.ldap_domain }}',
     ldap_is_active_directory: '{{ ctx.instance.runtime_properties.ldap_is_active_directory }}',
     ldap_dn_extra: '{{ ctx.instance.runtime_properties.ldap_dn_extra }}',
-    amqp_address: '{{ ctx.instance.runtime_properties.rabbitmq_endpoint_ip }}:{{ ctx.instance.runtime_properties.broker_port }}/',
+    amqp_address: '127.0.0.1:{{ ctx.instance.runtime_properties.broker_port }}/',
     amqp_username: '{{ ctx.instance.runtime_properties.rabbitmq_username }}',
     amqp_password: '{{ ctx.instance.runtime_properties.rabbitmq_password }}',
     amqp_ssl_enabled: {{ ctx.instance.runtime_properties.rabbitmq_ssl_enabled }},


### PR DESCRIPTION
If we're replicating the REST service config files across a cluster,
we need to make sure every node actually connects to its own
rabbitmq - let's use 127.0.0.1 for that (so every node will connect
to itself, when the config file is replicated to all the nodes),
instead of an externally-reachable ip