### PR TITLE
CFY-6562 Generate external ssl cert if not provided - bugfix

### DIFF
--- a/components/utils.py
+++ b/components/utils.py
@@ -277,7 +277,7 @@ def deploy_or_generate_external_ssl_cert(ip):
         )
         return cert_target_path, key_target_path
     except Exception as e:
-        if "No such file or directory" in str(e):
+        if "No such file or directory" in e.stderr:
             # pre-existing cert not found, generating new cert
             ctx.logger.info(
                 'Generating SSL certificate `{0}` and SSL private '


### PR DESCRIPTION
The error message isn't actually in `str(e)` but it is in `e.stderr`