### PR TITLE
Updated to more correct relationship

### DIFF
--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -321,7 +321,7 @@ node_templates:
       openstack_config: *openstack_configuration
       resource_id: { get_input: manager_port_name }
     relationships:
-      - type: cloudify.relationships.contained_in
+      - type: cloudify.relationships.connected_to
         target: management_network
       - type: cloudify.relationships.depends_on
         target: management_subnet


### PR DESCRIPTION
At runtime, it doesn't matter whether the port is `connected_to` the network or `contained_in`, because the code looks for any kind of a relationship. So the original code works. However, it serves as a bad example because this relationship between a port and a network is *incorrect*. Among other things, a `contained_in` relationship between a port and a network would prevent the user from using scaling groups to include a Server and a Port in the same scaling group; that wouldn't pass validation, because `Port` would be `contained_in` a network and thus `Server` and `Port` have an ancestry conflict.

As a matter of fact, there's room to consider removal of this relationship altogether. Ports in OpenStack are associated with subnets, not with networks.