### PR TITLE
CFY-6576 Make IPSetter and stage depend on manager_configuration

### DIFF
--- a/aws-ec2-manager-blueprint.yaml
+++ b/aws-ec2-manager-blueprint.yaml
@@ -513,6 +513,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb

--- a/azure-manager-blueprint.yaml
+++ b/azure-manager-blueprint.yaml
@@ -715,6 +715,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb

--- a/components/manager-ip-setter/node-template.yaml
+++ b/components/manager-ip-setter/node-template.yaml
@@ -5,3 +5,5 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration

--- a/openstack-manager-blueprint.yaml
+++ b/openstack-manager-blueprint.yaml
@@ -591,6 +591,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -433,6 +433,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb

--- a/vcloud-manager-blueprint.yaml
+++ b/vcloud-manager-blueprint.yaml
@@ -685,6 +685,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb

--- a/vsphere-manager-blueprint.yaml
+++ b/vsphere-manager-blueprint.yaml
@@ -571,6 +571,8 @@ node_templates:
     relationships:
       - type: cloudify.relationships.contained_in
         target: manager_host
+      - type: cloudify.relationships.depends_on
+        target: manager_configuration
       - type: stage_to_restservice
         target: rest_service
       - type: stage_to_influxdb


### PR DESCRIPTION
Every node that uses fabric (for .py scripts) needs to have a
depends_on relationship to the manager_configuration, because that's
where the host_string is taken from, for the fabric env.
(the relationship can be directly to manager_configuration, or
to some other node that depends on it)

Without this change, some nodes can be created before
manager_configuration, which will lead to an empty host_string in
their fabric inputs, and an error message from fabric.