### PR TITLE
CFY-6647 Set reported_timestamp when new event/log is inserted

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -76,7 +76,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO logs (reported_timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
               "%{[context][execution_id]}",
               "[logger]",
@@ -94,7 +94,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO events (reported_timestamp, _execution_fk, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",


### PR DESCRIPTION
The insert queries for new events/logs have been updated to use the timestamp provided by the event data structure to set the `reported_timestamp` field instead of the `timestamp` one. Now, `timestamp` will be populated automatically by the database using the current timestamp. 