### PR TITLE
CFY-6479 Insert error causes value into the events table

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -57,6 +57,16 @@ filter {
             }
         }
     }
+
+    # Set context.task_error_causes field to the empty string by default
+    # this will be inserted as null below thanks to NULLIF
+    if ![context][task_error_causes] {
+        mutate {
+            add_field => {
+                "[context][task_error_causes]" => ""
+            }
+        }
+    }
 }
 
 
@@ -84,14 +94,15 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO events (timestamp, _execution_fk, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
               "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",
               "[message_code]",
               "%{[context][operation]}",
-              "%{[context][node_id]}"
+              "%{[context][node_id]}",
+              "%{[context][task_error_causes]}"
             ]
         }
     }


### PR DESCRIPTION
In this PR, logstash configuration is updated to insert the error causes field into the events table if available.

Depends: cloudify-cosmo/cloudify-manager#799