### PR TITLE
CFY-6720 Add `Wants=dbus.service` to cloudify-restservice

### DIFF
--- a/components/restservice/config/cloudify-restservice.service
+++ b/components/restservice/config/cloudify-restservice.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cloudify REST Service
-Wants=network-online.target
+Wants=network-online.target dbus.service
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
The REST service uses DBus for the status endpoint, which makes DBus
a requirement for running the REST Service. Add the DBus service as
a 'Wants' in the REST unit file so that it is started if needed.