### PR TITLE
CFY-6660. Include _tenant_id and _created_id in event/log insert queries

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -76,8 +76,10 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (reported_timestamp, _execution_fk, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO logs (reported_timestamp, _execution_fk, _tenant_id, _creator_id, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), (SELECT _tenant_id FROM executions WHERE id = ?), (SELECT _creator_id FROM executions WHERE id = ?),  ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
+              "%{[context][execution_id]}",
+              "%{[context][execution_id]}",
               "%{[context][execution_id]}",
               "[logger]",
               "[level]",
@@ -94,8 +96,10 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (reported_timestamp, _execution_fk, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO events (reported_timestamp, _execution_fk, _tenant_id, _creator_id, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), (SELECT _tenant_id FROM executions WHERE id = ?), (SELECT _creator_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
               "@timestamp",
+              "%{[context][execution_id]}",
+              "%{[context][execution_id]}",
               "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",


### PR DESCRIPTION
In this PR, the logstash configuration is updated to include the `_tenant_id` and `_creator_id` fields in the event and log insert queries. This is because these fields are now part of both tables while in the past they where retrieved through an association proxy.