### PR TITLE
CFY-6660 Update insert queries to use one subquery

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -76,17 +76,15 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (reported_timestamp, _execution_fk, _tenant_id, _creator_id, logger, level, message, message_code, operation, node_id) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), (SELECT _tenant_id FROM executions WHERE id = ?), (SELECT _creator_id FROM executions WHERE id = ?),  ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO logs (reported_timestamp, _execution_fk, _tenant_id, _creator_id, logger, level, message, message_code, operation, node_id) SELECT CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
               "@timestamp",
-              "%{[context][execution_id]}",
-              "%{[context][execution_id]}",
-              "%{[context][execution_id]}",
               "[logger]",
               "[level]",
               "%{[message][text]}",
               "[message_code]",
               "%{[context][operation]}",
-              "%{[context][node_id]}"
+              "%{[context][node_id]}",
+              "%{[context][execution_id]}"
             ]
         }
     }
@@ -96,17 +94,15 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (reported_timestamp, _execution_fk, _tenant_id, _creator_id, event_type, message,  message_code, operation, node_id, error_causes) VALUES(CAST (? AS TIMESTAMP), (SELECT _storage_id FROM executions WHERE id = ?), (SELECT _tenant_id FROM executions WHERE id = ?), (SELECT _creator_id FROM executions WHERE id = ?), ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))",
+              "INSERT INTO events (reported_timestamp, _execution_fk, _tenant_id, _creator_id, event_type, message,  message_code, operation, node_id, error_causes) SELECT CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
               "@timestamp",
-              "%{[context][execution_id]}",
-              "%{[context][execution_id]}",
-              "%{[context][execution_id]}",
               "[event_type]",
               "%{[message][text]}",
               "[message_code]",
               "%{[context][operation]}",
               "%{[context][node_id]}",
-              "%{[context][task_error_causes]}"
+              "%{[context][task_error_causes]}",
+              "%{[context][execution_id]}"
             ]
         }
     }


### PR DESCRIPTION
In this PR, the logstash insert queries have been updated to use just a single subquery since all the subqueries were used to extract information from the same execution.