### PR TITLE
CFY 6479. Serialize error causes

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -66,6 +66,10 @@ filter {
                 "[context][task_error_causes]" => ""
             }
         }
+    } else {
+        json_encode {
+            source => "[context][task_error_causes]"
+        }
     }
 }
 

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -20,6 +20,15 @@ LOGSTASH_SERVICE_NAME = 'logstash'
 ctx_properties = utils.ctx_factory.create(LOGSTASH_SERVICE_NAME)
 
 
+def install_logstash_filter_json_encode_plugin():
+    """"Install filter plugin needed to encode json data."""
+    ctx.logger.info('Installing logstash-filter-json_encode plugin...')
+    utils.run([
+        'sudo', '-u', 'logstash',
+        '/opt/logstash/bin/plugin', 'install', 'logstash-filter-json_encode',
+    ])
+
+
 def install_logstash_output_jdbc_plugin():
     """"Install output plugin needed to write to SQL databases."""
     plugin_url = ctx_properties['logstash_output_jdbc_plugin_url']
@@ -65,6 +74,7 @@ def install_logstash():
 
     utils.yum_install(logstash_source_url, service_name=LOGSTASH_SERVICE_NAME)
 
+    install_logstash_filter_json_encode_plugin()
     install_logstash_output_jdbc_plugin()
     install_postgresql_jdbc_driver()
 


### PR DESCRIPTION
In this PR, the `error_causes` object is stored as a json-encode string in the `events` table.

To make this happen, the `logstash-filter-json_encode` plugin is installed and the logstash configuration is updated.

Note: the plugin is installed directly from the internet. When the resources file is updated with the `gem` file for the plugin, the installation function should be updated accordingly.