### PR TITLE
CFY 6479. Install logstash plugin from resources file

### DIFF
--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -20,26 +20,36 @@ LOGSTASH_SERVICE_NAME = 'logstash'
 ctx_properties = utils.ctx_factory.create(LOGSTASH_SERVICE_NAME)
 
 
-def install_logstash_filter_json_encode_plugin():
-    """"Install filter plugin needed to encode json data."""
-    ctx.logger.info('Installing logstash-filter-json_encode plugin...')
-    utils.run([
-        'sudo', '-u', 'logstash',
-        '/opt/logstash/bin/plugin', 'install', 'logstash-filter-json_encode',
-    ])
+def install_plugin(name, plugin_url):
+    """Install plugin.
 
+    :param name: Plugin name
+    :type name: str
+    :param plugin_url: Plugin file location
+    :type plugin_path: str
 
-def install_logstash_output_jdbc_plugin():
-    """"Install output plugin needed to write to SQL databases."""
-    plugin_url = ctx_properties['logstash_output_jdbc_plugin_url']
-
-    ctx.logger.info('Installing logstash-output-jdbc plugin...')
+    """
+    ctx.logger.info('Installing {} plugin...'.format(name))
     plugin_path = utils.download_cloudify_resource(
         plugin_url, service_name=LOGSTASH_SERVICE_NAME)
     utils.run([
         'sudo', '-u', 'logstash',
         '/opt/logstash/bin/plugin', 'install', plugin_path,
     ])
+
+
+def install_logstash_filter_json_encode_plugin():
+    """"Install filter plugin needed to encode json data."""
+    name = 'logstash-filter-json_encode'
+    plugin_url = ctx_properties['logstash_filter_json_encode_plugin_url']
+    install_plugin(name, plugin_url)
+
+
+def install_logstash_output_jdbc_plugin():
+    """"Install output plugin needed to write to SQL databases."""
+    name = 'logstash-output-jdbc'
+    plugin_url = ctx_properties['logstash_output_jdbc_plugin_url']
+    install_plugin(name, plugin_url)
 
 
 def install_postgresql_jdbc_driver():

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -210,8 +210,13 @@ inputs:
     type: string
     default: logstash-1.5.0-1.noarch.rpm
 
+  logstash_filter_json_encode_plugin_url:
+    description: logstash-filter-json_encode plugin location
+    type: string
+    default: logstash-filter-json_encode-0.1.5.gem
+
   logstash_output_jdbc_plugin_url:
-    description: logstash-output-jdbc-plugin location
+    description: logstash-output-jdbc plugin location
     type: string
     default: logstash-output-jdbc-0.2.10.gem
 
@@ -333,7 +338,7 @@ inputs:
       Not used if an external endpoint is used.
     type: integer
     default: 102400
-  
+
   #############################
   # PostgreSQL Inputs
   #############################

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -352,6 +352,9 @@ node_types:
         description: Logstash tar.gz Source URL
         type: string
         default: { get_input: logstash_source_url }
+      logstash_filter_json_encode_plugin_url:
+        description: logstash-filter-json_encode location
+        default: { get_input: logstash_filter_json_encode_plugin_url }
       logstash_output_jdbc_plugin_url:
         description: logstash-output-jdbc-plugin location
         default: { get_input: logstash_output_jdbc_plugin_url }
@@ -608,7 +611,7 @@ node_types:
       use_existing_on_upgrade:
         description: Use existing rest service configuration on upgrade
         type: string
-        default: true       
+        default: true
       gunicorn_worker_count:
         description: |
           The number of worker processes for handling requests.


### PR DESCRIPTION
In this PR, the changes needed to install the `logstash-filter-json_encode` plugin from the cloudify manager resources file have been made.

The resources file change is in progress, so the PR will be merged only after the resources file has been updated.