### PR TITLE
CFY-6745 Use rngd to feed /dev/random from /dev/urandom

### DIFF
--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -84,6 +84,11 @@ def install_logstash():
 
     utils.yum_install(logstash_source_url, service_name=LOGSTASH_SERVICE_NAME)
 
+    # Make sure there's enough entropy in /dev/random
+    # before installing plugins
+    utils.run(['sudo', 'yum', 'install', '-y', 'rng-tools'])
+    utils.run(['sudo', 'rngd', '-r', '/dev/urandom'])
+
     install_logstash_filter_json_encode_plugin()
     install_logstash_output_jdbc_plugin()
     install_postgresql_jdbc_driver()


### PR DESCRIPTION
This PR is a quick fix to use `rngd` to feed `/dev/random` from `/dev/urandom`.

This way logstash plugin installation doesn't stall because of lack of entropy