### PR TITLE
CFY 6745. Use haveged

### DIFF
--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -84,10 +84,9 @@ def install_logstash():
 
     utils.yum_install(logstash_source_url, service_name=LOGSTASH_SERVICE_NAME)
 
-    # Make sure there's enough entropy in /dev/random
-    # before installing plugins
-    utils.run(['sudo', 'yum', 'install', '-y', 'rng-tools'])
-    utils.run(['sudo', 'rngd', '-r', '/dev/urandom'])
+    # Make sure there's enough entropy in /dev/random before installing plugins
+    haveged_source_url = ctx_properties['haveged_rpm_source_url']
+    utils.yum_install(haveged_source_url, service_name='haveged')
 
     install_logstash_filter_json_encode_plugin()
     install_logstash_output_jdbc_plugin()

--- a/components/logstash/scripts/create.py
+++ b/components/logstash/scripts/create.py
@@ -88,9 +88,13 @@ def install_logstash():
     haveged_source_url = ctx_properties['haveged_rpm_source_url']
     utils.yum_install(haveged_source_url, service_name='haveged')
 
-    install_logstash_filter_json_encode_plugin()
-    install_logstash_output_jdbc_plugin()
-    install_postgresql_jdbc_driver()
+    utils.systemd.start('haveged', append_prefix=False)
+    try:
+        install_logstash_filter_json_encode_plugin()
+        install_logstash_output_jdbc_plugin()
+        install_postgresql_jdbc_driver()
+    finally:
+        utils.systemd.stop('haveged', append_prefix=False)
 
     utils.mkdir(logstash_log_path)
     utils.chown('logstash', 'logstash', logstash_log_path)

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -220,6 +220,10 @@ inputs:
     type: string
     default: logstash-output-jdbc-0.2.10.gem
 
+  haveged_source_url:
+    type: string
+    default: haveged-1.9.1-1.el7.x86_64.rpm
+
   nginx_source_url:
     type: string
     default: nginx-1.8.0-1.el7.ngx.x86_64.rpm

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -362,6 +362,10 @@ node_types:
         description: PostgreSQL JDBC driver
         type: string
         default: { get_input: postgresql_jdbc_driver_url }
+      haveged_rpm_source_url:
+        description: haveged rpm source url
+        type: string
+        default: { get_input: haveged_source_url }
       use_existing_on_upgrade:
         description: Use existing logstash configuration
         type: string


### PR DESCRIPTION
Since it seems that `rngd -r /dev/urandom` is not really a good practice, in this PR `haveged` is used instead.

Also, the `haveged` service is started/stopped before/after installation of the logstash plugins. This doesn't guarantee that entropy generated by `haveged` is not used later for some other things, but still this should be a safer approach than leaving `haveged` running.

Note that these changes expect to find the `haveged` rpm in the cloudify manager resources file, so this PR won't be merged until the new resources files has been generated.