### PR TITLE
postgresql .pgpass: only move after closing the file

### DIFF
--- a/components/postgresql/scripts/start.py
+++ b/components/postgresql/scripts/start.py
@@ -63,13 +63,13 @@ def _create_postgres_pass_file(host, db_name, username, password):
         os.remove(pgpass_path)
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_file.write(pgpass_content)
-        temp_file.flush()
-        utils.chmod('0600', temp_file.name)
-        utils.move(source=temp_file.name,
-                   destination=pgpass_path,
-                   rename_only=True)
-        ctx.logger.debug('Postgresql pass file {0} created'.format(
-            pgpass_path))
+
+    utils.chmod('0600', temp_file.name)
+    utils.move(source=temp_file.name,
+               destination=pgpass_path,
+               rename_only=True)
+    ctx.logger.debug('Postgresql pass file {0} created'.format(
+        pgpass_path))
 
 
 def main():


### PR DESCRIPTION
It seems it might be a race condition to only `.flush()`, and then `move()` (since move uses a separate `mv` process?)

Observed behaviour was, the `/root/.pgpass` file was empty after bootstrap (seems very rare)