### PR TITLE
Remove C_FORCE_ROOT from celery config

### DIFF
--- a/components/mgmtworker/config/cloudify-mgmtworker
+++ b/components/mgmtworker/config/cloudify-mgmtworker
@@ -14,4 +14,3 @@ MANAGER_FILE_SERVER_ROOT="{{ ctx.instance.runtime_properties.file_server_root }}
 CELERY_TASK_SERIALIZER="json"
 CELERY_RESULT_SERIALIZER="json"
 CELERY_RESULT_BACKEND="amqp"
-C_FORCE_ROOT=true


### PR DESCRIPTION
No longer needed, as we're no longer running celery as root