### PR TITLE
CFY-6844

### DIFF
--- a/components/nginx/config/https-external-rest-server.cloudify
+++ b/components/nginx/config/https-external-rest-server.cloudify
@@ -29,6 +29,6 @@ server {
 
   # the nginx version shipped with centos has no native 308 support - we need
   # to add the header manually.
-  add_header Location https://$server_name$request_uri always;
+  add_header Location https://$host$request_uri always;
   return 308;
 }


### PR DESCRIPTION
Fixed redirection to use `$host` (expands to whatever the user entered in the address bar) instead of `$server_name` (which will expand to whatever is in the `server_name` field, which may be `127.0.0.1` for images).