### PR TITLE
CFY-7005. Insert timestamp explicitly in logstash events/logs

### DIFF
--- a/components/logstash/config/logstash.conf
+++ b/components/logstash/config/logstash.conf
@@ -80,7 +80,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO logs (reported_timestamp, _execution_fk, _tenant_id, _creator_id, logger, level, message, message_code, operation, node_id) SELECT CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
+              "INSERT INTO logs (timestamp, reported_timestamp, _execution_fk, _tenant_id, _creator_id, logger, level, message, message_code, operation, node_id) SELECT now() AT TIME ZONE 'utc', CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
               "@timestamp",
               "[logger]",
               "[level]",
@@ -98,7 +98,7 @@ output {
             driver_class => 'org.postgresql.Driver'
             connection_string => 'jdbc:postgresql://{{ ctx.instance.runtime_properties.postgresql_host }}:5432/{{ ctx.instance.runtime_properties.postgresql_db_name }}?user={{ ctx.instance.runtime_properties.postgresql_username }}&password={{ ctx.instance.runtime_properties.postgresql_password }}'
             statement => [
-              "INSERT INTO events (reported_timestamp, _execution_fk, _tenant_id, _creator_id, event_type, message,  message_code, operation, node_id, error_causes) SELECT CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
+              "INSERT INTO events (timestamp, reported_timestamp, _execution_fk, _tenant_id, _creator_id, event_type, message,  message_code, operation, node_id, error_causes) SELECT now() AT TIME ZONE 'utc', CAST (? AS TIMESTAMP), _storage_id, _tenant_id, _creator_id, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, '') FROM executions WHERE id = ?",
               "@timestamp",
               "[event_type]",
               "%{[message][text]}",


### PR DESCRIPTION
In this PR, logstash configuration is updated to insert explicitly a timestamp value in UTC.

This is because there is no longer a default value for the events/logs tables at the database level. Hence, logstash must provide the value on its own and make sure that is in UTC.

Related: cloudify-cosmo/cloudify-manager#894