### PR TITLE
Add premium_source_url dev input

### DIFF
--- a/components/restservice/scripts/create.py
+++ b/components/restservice/scripts/create.py
@@ -35,6 +35,7 @@ def install_optional(rest_venv):
     plugins_common_source_url = props['plugins_common_module_source_url']
     script_plugin_source_url = props['script_plugin_module_source_url']
     agent_source_url = props['agent_module_source_url']
+    premium_source_url = props['premium_module_source_url']
     pip_constraints = props['pip_constraints']
 
     rest_service_source_url = props['rest_service_module_source_url']
@@ -79,6 +80,10 @@ def install_optional(rest_venv):
         utils.move(resources_dir, utils.MANAGER_RESOURCES_HOME)
 
         utils.remove(tmp_dir)
+
+    if premium_source_url:
+        utils.install_python_package(premium_source_url, rest_venv,
+                                     constraints_file)
 
     if constraints_file:
         os.remove(constraints_file)

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -495,6 +495,10 @@ inputs:
     type: string
     default: ''
 
+  premium_source_url:
+    type: string
+    default: ''
+
   sanity_app_source_url:
     type: string
     default: cloudify-hello-world-example-*.tar.gz

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -658,6 +658,10 @@ node_types:
         description: Agent module Source URL
         type: string
         default: { get_input: agent_source_url }
+      premium_module_source_url:
+        description: Agent module Source URL
+        type: string
+        default: { get_input: premium_source_url }
       plugins:
         description: Enables installing custom plugins on the rest service
         default: {}


### PR DESCRIPTION
Cloudify-premium can now be installed from source during bootstrap,
so that developers can use alternate branches.