### PR TITLE
CFY-7215 Use storage_manager directly in ipsetter

### DIFF
--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -6,7 +6,7 @@ Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker
 TimeoutStartSec=0
 User={{ ctx.instance.runtime_properties.service_user }}
 Group={{ ctx.instance.runtime_properties.service_group }}
-EnvironmentFile=-/etc/sysconfig/cloudify-manager-ip-setter
+EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/bin/sudo /opt/cloudify/manager-ip-setter/manager-ip-setter.sh
 
 [Install]

--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -4,10 +4,10 @@ Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker
 
 [Service]
 TimeoutStartSec=0
-User={{ ctx.instance.runtime_properties.service_user }}
-Group={{ ctx.instance.runtime_properties.service_group }}
+User=root
+Group=root
 EnvironmentFile=-/etc/sysconfig/cloudify-restservice
-ExecStart=/bin/sudo /opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+ExecStart=/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
 
 [Install]
 WantedBy=default.target

--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -6,7 +6,6 @@ Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker
 TimeoutStartSec=0
 User=root
 Group=root
-EnvironmentFile=-/etc/sysconfig/cloudify-restservice
 ExecStart=/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
 
 [Install]

--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cloudify Manager IP Setter
-After=network.target cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker.service cloudify-restservice.service cloudify-riemann.service cloudify-stage.service nginx.service
+Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker.service cloudify-restservice.service cloudify-riemann.service cloudify-stage.service nginx.service cloudify-rabbitmq.service
 
 [Service]
 TimeoutStartSec=0

--- a/components/manager-ip-setter/scripts/manager-ip-setter.sh
+++ b/components/manager-ip-setter/scripts/manager-ip-setter.sh
@@ -27,7 +27,7 @@ function set_manager_ip() {
   /usr/bin/sed -i -e "s/"'"'"broker_hostname"'"'": "'"'".*"'"'"/"'"'"broker_hostname"'"'": "'"'"${ip}"'"'"/" /opt/mgmtworker/work/broker_config.json
 
   echo "Updating broker_ip in provider context.."
-  /opt/mgmtworker/env/bin/python /opt/cloudify/manager-ip-setter/update-provider-context.py ${ip}
+  /opt/manager/env/bin/python /opt/cloudify/manager-ip-setter/update-provider-context.py ${ip}
 
   echo "Creating internal SSL certificates.."
   /opt/mgmtworker/env/bin/python /opt/cloudify/manager-ip-setter/create-internal-ssl-certs.py ${ip}

--- a/components/manager-ip-setter/scripts/manager-ip-setter.sh
+++ b/components/manager-ip-setter/scripts/manager-ip-setter.sh
@@ -32,26 +32,6 @@ function set_manager_ip() {
   echo "Creating internal SSL certificates.."
   /opt/mgmtworker/env/bin/python /opt/cloudify/manager-ip-setter/create-internal-ssl-certs.py ${ip}
   
-  echo "Restarting services.."
-  # Restarting all (except postgres) to avoid issues with not correctly reloading SSL certs
-  systemctl restart nginx
-  systemctl restart cloudify-amqpinflux
-  systemctl restart cloudify-influxdb
-  systemctl restart cloudify-mgmtworker
-  systemctl restart cloudify-rabbitmq
-  systemctl restart cloudify-restservice
-  systemctl restart cloudify-riemann
-  # Only on premium
-  if $(systemctl list-units | grep cloudify-stage > /dev/null); then
-      systemctl restart cloudify-stage
-  fi
-  if $(systemctl list-units | grep cloudify-composer > /dev/null); then
-      systemctl restart cloudify-composer
-  fi
-
-  echo "Restarting rabbitmq.."
-  systemctl restart cloudify-rabbitmq
-
   echo "Done!"
 
 }

--- a/components/manager-ip-setter/scripts/update-provider-context.py
+++ b/components/manager-ip-setter/scripts/update-provider-context.py
@@ -1,56 +1,17 @@
-#!/bin/python
-
-import json
 import sys
-import time
-
-import requests
+from manager_rest.server import app
+from manager_rest.storage import get_storage_manager, models
+from manager_rest.constants import PROVIDER_CONTEXT_ID
+from sqlalchemy.orm.attributes import flag_modified
 
 
 def update_provider_context(manager_ip):
-    username = "{{ ctx.node.properties.admin_username }}"
-    password = "{{ ctx.node.properties.admin_password }}"
-    auth = (username, password)
-    headers = {"Tenant": "default_tenant", 'Content-Type': 'application/json'}
-    print('- Getting provider context...')
-    attempt = 1
-    while True:
-        try:
-            r = requests.get(
-                'http://localhost/api/version', auth=auth, headers=headers)
-            if r.status_code == 200:
-                print('- REST API is up!')
-                break
-            if attempt == 10:
-                break
-        except Exception as e:
-            print('- Error accessing REST API: {}'.format(e))
-        print('- REST API not yet up.. retrying in 5 seconds..')
-        time.sleep(5)
-        attempt += 1
-
-    r = requests.get(
-        'http://localhost/api/v3.1/provider/context',
-        auth=auth, headers=headers)
-    if r.status_code != 200:
-        print("Failed getting provider context.")
-        print(r.text)
-        sys.exit(1)
-    response = r.json()
-    name = response['name']
-    context = response['context']
-    context['cloudify']['cloudify_agent']['broker_ip'] = manager_ip
-    print('- Updating provider context...')
-    data = {'name': name, 'context': context}
-    r = requests.post(
-        'http://localhost/api/v3.1/provider/context',
-        auth=auth, headers=headers,
-        params={'update': 'true'},
-        data=json.dumps(data))
-    if r.status_code != 200:
-        print("Failed updating provider context.")
-        print(r.text)
-        sys.exit(1)
+    with app.app_context():
+        sm = get_storage_manager()
+        ctx = sm.get(models.ProviderContext, PROVIDER_CONTEXT_ID)
+        ctx.context['cloudify']['cloudify_agent']['broker_ip'] = manager_ip
+        flag_modified(ctx, 'context')
+        sm.update(ctx)
 
 
 if __name__ == '__main__':

--- a/components/manager-ip-setter/scripts/update-provider-context.py
+++ b/components/manager-ip-setter/scripts/update-provider-context.py
@@ -1,12 +1,12 @@
 import sys
-from manager_rest.server import app
+from manager_rest.flask_utils import setup_flask_app
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.constants import PROVIDER_CONTEXT_ID
 from sqlalchemy.orm.attributes import flag_modified
 
 
 def update_provider_context(manager_ip):
-    with app.app_context():
+    with setup_flask_app().app_context():
         sm = get_storage_manager()
         ctx = sm.get(models.ProviderContext, PROVIDER_CONTEXT_ID)
         ctx.context['cloudify']['cloudify_agent']['broker_ip'] = manager_ip


### PR DESCRIPTION
Instead of using the REST API to update provider context, simply use
restservice's storage_manager directly - this makes it faster, and avoids
a circular dependency issue (where restservice needs to be started for
ipsetter to work, but without ipsetter, restservice is using the wrong cert)