### PR TITLE
CFY-7200 Add a `manager_networks` bootstrap input

### DIFF
--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -30,6 +30,18 @@ inputs:
     type: boolean
     default: true
 
+  #############################
+  # Network configurations
+  #############################
+
+  manager_networks:
+    description: >
+      A list of network names and IP addresses associated with them.
+      By default, there is only a "default" network, with the manager's
+      private IP associated with it. This network can be overwritten
+    default:
+      - default: { get_input: private_ip }
+
   #################################
   # REST Configuration
   #################################

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -129,6 +129,7 @@ node_templates:
           user: { get_input: agents_user }
           broker_user: { get_input: rabbitmq_username }
           broker_pass: { get_input: rabbitmq_password }
+          networks: { get_input: manager_networks }
 
         workflows:
           task_retries: { get_input: workflow_task_retries }


### PR DESCRIPTION
This input will be set in `cloudify.cloudify_agent.networks`,
and subsequently in the provider context.