### PR TITLE
CFY-7215 Run IPSetter after the network is online

### DIFF
--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cloudify Manager IP Setter
 Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker.service cloudify-restservice.service cloudify-riemann.service cloudify-stage.service nginx.service cloudify-rabbitmq.service
+After=network-online.target
 
 [Service]
 TimeoutStartSec=0


### PR DESCRIPTION
If we don't declare that the IPSetter must run after network-online,
it might be run before networks have been set up, and then it won't
find the server IP and will fail.

This change makes it run after network-online, so the IP will be
found correctly.