### PR TITLE
CFY-7215 Use Type=oneshot for IPSetter

### DIFF
--- a/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
+++ b/components/manager-ip-setter/config/cloudify-manager-ip-setter.service
@@ -4,6 +4,7 @@ Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker
 After=network-online.target
 
 [Service]
+Type=oneshot
 TimeoutStartSec=0
 User=root
 Group=root


### PR DESCRIPTION
For type=oneshot services, the services depended on it, will wait for
the oneshot service to finish before they run.

Without this, IPSetter is the default "simple" type, which means that
nginx might start running BEFORE ipsetter finishes, and then nginx
will be using the old certificate, before it was replaced.