### PR TITLE
CFY-7190 Use a separate CA cert

### DIFF
--- a/components/amqpinflux/scripts/create.py
+++ b/components/amqpinflux/scripts/create.py
@@ -60,7 +60,7 @@ def install_amqpinflux():
     ctx.logger.info('Configuring AMQPInflux...')
     utils.create_service_user(AMQPINFLUX_USER, AMQPINFLUX_GROUP, HOME_DIR)
     ctx.instance.runtime_properties['broker_cert_path'] = \
-        utils.INTERNAL_CERT_PATH
+        utils.INTERNAL_CA_CERT_PATH
     utils.chown(AMQPINFLUX_USER, AMQPINFLUX_GROUP, HOME_DIR)
     utils.systemd.configure(SERVICE_NAME)
 

--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -1,6 +1,6 @@
 
 # This script has to run using the Python executable found in:
-# /opt/cfy/embedded/bin/python in order to properly load the manager
+# /opt/mgmtworker/env/bin/python in order to properly load the manager
 # blueprints utils.py module.
 
 import logging
@@ -21,4 +21,9 @@ if __name__ == '__main__':
         print('Expected 1 argument - <manager-ip>')
         print('Provided args: {0}'.format(sys.argv[1:]))
         sys.exit(1)
-    utils.generate_internal_ssl_cert(sys.argv[1])
+    internal_rest_host = sys.argv[1]
+    cert_metadata = utils.load_cert_metadata()
+    networks = cert_metadata.get('networks', {})
+    cert_ips = [internal_rest_host] + list(networks.values())
+    utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
+    utils.store_cert_metadata(internal_rest_host)

--- a/components/manager-ip-setter/scripts/create.py
+++ b/components/manager-ip-setter/scripts/create.py
@@ -36,23 +36,6 @@ def deploy_utils():
     utils.chown('root', utils.CLOUDIFY_GROUP, utils_path)
 
 
-def create_cloudify_user():
-    utils.create_service_user(
-        user=utils.CLOUDIFY_USER,
-        group=utils.CLOUDIFY_GROUP,
-        home=utils.CLOUDIFY_HOME_DIR
-    )
-    utils.mkdir(utils.CLOUDIFY_HOME_DIR)
-
-
-def create_sudoers_file_and_disable_sudo_requiretty():
-    utils.sudo(['touch', utils.CLOUDIFY_SUDOERS_FILE])
-    utils.chmod('440', utils.CLOUDIFY_SUDOERS_FILE)
-    entry = 'Defaults:{user} !requiretty'.format(user=utils.CLOUDIFY_USER)
-    description = 'Disable sudo requiretty for {0}'.format(utils.CLOUDIFY_USER)
-    utils.add_entry_to_sudoers(entry, description)
-
-
 def deploy_sudo_scripts():
     scripts_to_deploy = {
         'manager-ip-setter.sh': 'Run manager IP setter script',
@@ -73,13 +56,7 @@ def install_manager_ip_setter():
     utils.systemd.configure(SERVICE_NAME)
 
 
-def init_cloudify_user():
-    create_cloudify_user()
-    create_sudoers_file_and_disable_sudo_requiretty()
-
-
 # Always create the cloudify user, but only install the scripts if flag is true
-init_cloudify_user()
 if os.environ.get('set_manager_ip_on_boot').lower() == 'true':
     install_manager_ip_setter()
 else:

--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -82,6 +82,6 @@ def init_cloudify_user():
     create_sudoers_file_and_disable_sudo_requiretty()
 
 
+init_cloudify_user()
 configure_security_properties()
 create_certs()
-init_cloudify_user()

--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -55,6 +55,7 @@ def create_certs():
     utils.generate_ca_cert()
     networks = ctx_properties['cloudify']['cloudify_agent']['networks']
     internal_rest_host = ctx.instance.runtime_properties['internal_rest_host']
+    utils.store_cert_metadata(internal_rest_host, networks)
     cert_ips = [internal_rest_host] + list(networks.values())
     utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
 

--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -52,4 +52,14 @@ def configure_security_properties():
     runtime_props['external_rest_protocol'] = external_rest_protocol
 
 
+def create_certs():
+    utils.mkdir(utils.SSL_CERTS_TARGET_DIR)
+    utils.generate_ca_cert()
+    networks = ctx_properties['cloudify']['cloudify_agent']['networks']
+    internal_rest_host = ctx.instance.runtime_properties['internal_rest_host']
+    cert_ips = [internal_rest_host] + list(networks.values())
+    utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
+
+
 configure_security_properties()
+create_certs()

--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -34,8 +34,6 @@ def configure_security_properties():
     security_config = ctx_properties['security']
     runtime_props = ctx.instance.runtime_properties
 
-    runtime_props['internal_rest_port'] = utils.INTERNAL_REST_PORT
-
     if security_config['ssl']['enabled']:
         # manager SSL settings
         ctx.logger.info('SSL is enabled, setting rest port to 443 and '

--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -59,5 +59,28 @@ def create_certs():
     utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
 
 
+def create_cloudify_user():
+    utils.create_service_user(
+        user=utils.CLOUDIFY_USER,
+        group=utils.CLOUDIFY_GROUP,
+        home=utils.CLOUDIFY_HOME_DIR
+    )
+    utils.mkdir(utils.CLOUDIFY_HOME_DIR)
+
+
+def create_sudoers_file_and_disable_sudo_requiretty():
+    utils.sudo(['touch', utils.CLOUDIFY_SUDOERS_FILE])
+    utils.chmod('440', utils.CLOUDIFY_SUDOERS_FILE)
+    entry = 'Defaults:{user} !requiretty'.format(user=utils.CLOUDIFY_USER)
+    description = 'Disable sudo requiretty for {0}'.format(utils.CLOUDIFY_USER)
+    utils.add_entry_to_sudoers(entry, description)
+
+
+def init_cloudify_user():
+    create_cloudify_user()
+    create_sudoers_file_and_disable_sudo_requiretty()
+
+
 configure_security_properties()
 create_certs()
+init_cloudify_user()

--- a/components/manager/scripts/set_manager_ips.py
+++ b/components/manager/scripts/set_manager_ips.py
@@ -20,6 +20,7 @@ from cloudify.state import ctx_parameters as inputs
 from cloudify.exceptions import NonRecoverableError
 
 
+INTERNAL_REST_PORT = 53333
 source_runtime_props = ctx.source.instance.runtime_properties
 
 # set private ip according to the host ip (backward compatible)
@@ -66,6 +67,7 @@ else:
                               format(rest_host_internal_endpoint_type))
 ctx.logger.debug('internal_rest_host set to: {0}'.format(
     source_runtime_props['internal_rest_host']))
+source_runtime_props['internal_rest_port'] = INTERNAL_REST_PORT
 
 # Set the file server url
 file_server_url = 'https://{0}:{1}/resources'.format(

--- a/components/mgmtworker/scripts/create.py
+++ b/components/mgmtworker/scripts/create.py
@@ -121,7 +121,7 @@ def install_mgmtworker():
     _install_optional(mgmtworker_venv)
 
     # Add certificate and select port, as applicable
-    runtime_props['broker_cert_path'] = utils.INTERNAL_CERT_PATH
+    runtime_props['broker_cert_path'] = utils.INTERNAL_CA_CERT_PATH
     # Use SSL port
     runtime_props['broker_port'] = AMQP_SSL_PORT
 

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -87,18 +87,15 @@ def preconfigure_nginx():
     # This is used by nginx's default.conf to select the relevant configuration
     external_rest_protocol = target_runtime_props['external_rest_protocol']
     internal_rest_port = target_runtime_props['internal_rest_port']
-    internal_cert_path, internal_key_path = utils.generate_internal_ssl_cert(
-        target_runtime_props['internal_rest_host']
-    )
 
     src_runtime_props['external_rest_protocol'] = external_rest_protocol
+    src_runtime_props['internal_cert_path'] = utils.INTERNAL_CERT_PATH
+    src_runtime_props['internal_key_path'] = utils.INTERNAL_KEY_PATH
     src_runtime_props['internal_rest_port'] = internal_rest_port
-    src_runtime_props['internal_cert_path'] = internal_cert_path
-    src_runtime_props['internal_key_path'] = internal_key_path
     src_runtime_props['file_server_root'] = utils.MANAGER_RESOURCES_HOME
 
     # Pass on the the path to the certificate to manager_configuration
-    target_runtime_props['internal_cert_path'] = internal_cert_path
+    target_runtime_props['internal_cert_path'] = utils.INTERNAL_CA_CERT_PATH
 
     external_cert_path, external_key_path = \
         utils.deploy_or_generate_external_ssl_cert(

--- a/components/rabbitmq/config/rabbitmq.config
+++ b/components/rabbitmq/config/rabbitmq.config
@@ -3,7 +3,7 @@
  {rabbit, [
            {loopback_users, []},
            {ssl_listeners, [5671]},
-           {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},
+           {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"},
                           {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
                           {versions, ['tlsv1.2', 'tlsv1.1']}

--- a/components/restservice/scripts/create.py
+++ b/components/restservice/scripts/create.py
@@ -123,7 +123,7 @@ def install_restservice():
     utils.mkdir(agent_dir)
 
     runtime_props['rabbitmq_endpoint_ip'] = utils.get_rabbitmq_endpoint_ip()
-    runtime_props['broker_cert_path'] = utils.INTERNAL_CERT_PATH
+    runtime_props['broker_cert_path'] = utils.INTERNAL_CA_CERT_PATH
     utils.yum_install(rest_service_rpm_source_url,
                       service_name=SERVICE_NAME)
     _configure_dbus(rest_venv)

--- a/components/utils.py
+++ b/components/utils.py
@@ -41,7 +41,6 @@ INTERNAL_SSL_KEY_FILENAME = 'cloudify_internal_key.pem'
 INTERNAL_SSL_CA_CERT_FILENAME = 'cloudify_internal_ca_cert.pem'
 INTERNAL_SSL_CA_KEY_FILENAME = 'cloudify_internal_ca_key.pem'
 INTERNAL_PKCS12_FILENAME = 'cloudify_internal.p12'
-INTERNAL_REST_PORT = 53333
 INTERNAL_CERT_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
                                   INTERNAL_SSL_CERT_FILENAME)
 INTERNAL_KEY_PATH = os.path.join(SSL_CERTS_TARGET_DIR,

--- a/components/utils.py
+++ b/components/utils.py
@@ -359,6 +359,18 @@ def _generate_ssl_certificate(ips,
                               sign_key=INTERNAL_CA_KEY_PATH):
     """Generate a public SSL certificate and a private SSL key
 
+    :param ips: the ips (or names) to be used for subjectAltNames
+    :type ips: List[str]
+    :param cn: the subject commonName for the new certificate
+    :type cn: str
+    :param cert_path: path to save the new certificate to
+    :type cert_path: str
+    :param key_path: path to save the key for the new certificate to
+    :type key_path: str
+    :param sign_cert: path to the signing cert (internal CA by default)
+    :type sign_cert: str
+    :param sign_key: path to the signing cert's key (internal CA by default)
+    :type sign_key: str
     :return: The path to the cert and key files on the manager
     """
     # Remove duplicates from ips

--- a/components/utils.py
+++ b/components/utils.py
@@ -38,8 +38,21 @@ MANAGER_RESOURCES_SNAPSHOT_PATHS = [
 SSL_CERTS_TARGET_DIR = '/etc/cloudify/ssl'
 INTERNAL_SSL_CERT_FILENAME = 'cloudify_internal_cert.pem'
 INTERNAL_SSL_KEY_FILENAME = 'cloudify_internal_key.pem'
+INTERNAL_SSL_CA_CERT_FILENAME = 'cloudify_internal_ca_cert.pem'
+INTERNAL_SSL_CA_KEY_FILENAME = 'cloudify_internal_ca_key.pem'
 INTERNAL_PKCS12_FILENAME = 'cloudify_internal.p12'
 INTERNAL_REST_PORT = 53333
+INTERNAL_CERT_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
+                                  INTERNAL_SSL_CERT_FILENAME)
+INTERNAL_KEY_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
+                                 INTERNAL_SSL_KEY_FILENAME)
+INTERNAL_CA_CERT_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
+                                     INTERNAL_SSL_CA_CERT_FILENAME)
+INTERNAL_CA_KEY_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
+                                    INTERNAL_SSL_CA_KEY_FILENAME)
+CERT_METADATA_FILE_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
+                                       'certificate_metadata')
+
 
 BASE_LOG_DIR = '/var/log/cloudify'
 
@@ -56,12 +69,6 @@ CLOUDIFY_HOME_DIR = '/etc/cloudify'
 SUDOERS_INCLUDE_DIR = '/etc/sudoers.d'
 CLOUDIFY_SUDOERS_FILE = os.path.join(SUDOERS_INCLUDE_DIR, CLOUDIFY_USER)
 
-INTERNAL_CERT_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
-                                  INTERNAL_SSL_CERT_FILENAME)
-INTERNAL_KEY_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
-                                 INTERNAL_SSL_KEY_FILENAME)
-CERT_METADATA_FILE_PATH = os.path.join(SSL_CERTS_TARGET_DIR,
-                                       'certificate_metadata')
 CLUSTER_DELETE_SCRIPT = '/opt/cloudify/delete_cluster.py'
 CFY_EXEC_TEMPDIR_ENVVAR = 'CFY_EXEC_TEMP'
 

--- a/components/utils.py
+++ b/components/utils.py
@@ -333,6 +333,24 @@ def _format_ips(ips):
     return cert_metadata
 
 
+def store_cert_metadata(internal_rest_host, networks=None):
+    metadata = load_cert_metadata()
+    metadata['internal_rest_host'] = internal_rest_host
+    if networks is not None:
+        metadata['networks'] = networks
+    contents = json.dumps(metadata)
+    sudo_write_to_file(contents, CERT_METADATA_FILE_PATH)
+    chown(CLOUDIFY_USER, CLOUDIFY_GROUP, CERT_METADATA_FILE_PATH)
+
+
+def load_cert_metadata():
+    try:
+        with open(CERT_METADATA_FILE_PATH) as f:
+            return json.load(f)
+    except IOError:
+        return {}
+
+
 def _generate_ssl_certificate(ips,
                               cn,
                               cert_path,

--- a/simple-manager-blueprint.yaml
+++ b/simple-manager-blueprint.yaml
@@ -172,7 +172,7 @@ node_templates:
         target: manager_host
         target_interfaces:
           cloudify.interfaces.relationship_lifecycle:
-            postconfigure:
+            preconfigure:
               implementation: components/manager/scripts/set_manager_ips.py
               inputs:
                 public_ip: { get_property: [manager_host, public_ip] }


### PR DESCRIPTION
This also handles CFY-7191 (sign the new certs using the CA certs).

Instead of creating just an internal cert, and using that for everything,
we now separately create a CA cert, which is used (by the manager,
and by the agents) to verify connections, and an internal cert, which
is used by the servers.

This also contains several seemingly unrelated changes that were
required to do this sanely (but increase the overall quality IMO!),
so ideally go commit-by-commit while reviewing this.
