### PR TITLE
CFY-7220 A way to recreate the certs with the current CA

### DIFF
--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -17,12 +17,12 @@ utils.ctx = CtxWithLogger()
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print('Expected 1 argument - <manager-ip>')
-        print('Provided args: {0}'.format(sys.argv[1:]))
-        sys.exit(1)
-    internal_rest_host = sys.argv[1]
     cert_metadata = utils.load_cert_metadata()
+    if len(sys.argv) == 2:
+        internal_rest_host = sys.argv[1]
+    else:
+        internal_rest_host = cert_metadata['internal_rest_host']
+
     networks = cert_metadata.get('networks', {})
     cert_ips = [internal_rest_host] + list(networks.values())
     utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)

--- a/components/manager-ip-setter/scripts/create.py
+++ b/components/manager-ip-setter/scripts/create.py
@@ -53,11 +53,15 @@ def install_manager_ip_setter():
     utils.set_service_as_cloudify_service(runtime_props)
     deploy_utils()
     deploy_sudo_scripts()
+
+
+def enable_manager_ip_setter():
     utils.systemd.configure(SERVICE_NAME)
 
 
 # Always create the cloudify user, but only install the scripts if flag is true
+install_manager_ip_setter()
 if os.environ.get('set_manager_ip_on_boot').lower() == 'true':
-    install_manager_ip_setter()
+    enable_manager_ip_setter()
 else:
     ctx.logger.info('Set manager ip on boot is disabled.')


### PR DESCRIPTION
This allows using the script from ipsetter to re-create the internal cert with
the current CA, after the CA has been replicated from a cluster master,
after a join to a cluster.
