### PR TITLE
Create the certs in nginx's create.py script

### DIFF
--- a/components/manager/scripts/configure_manager.py
+++ b/components/manager/scripts/configure_manager.py
@@ -50,16 +50,6 @@ def configure_security_properties():
     runtime_props['external_rest_protocol'] = external_rest_protocol
 
 
-def create_certs():
-    utils.mkdir(utils.SSL_CERTS_TARGET_DIR)
-    utils.generate_ca_cert()
-    networks = ctx_properties['cloudify']['cloudify_agent']['networks']
-    internal_rest_host = ctx.instance.runtime_properties['internal_rest_host']
-    utils.store_cert_metadata(internal_rest_host, networks)
-    cert_ips = [internal_rest_host] + list(networks.values())
-    utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
-
-
 def create_cloudify_user():
     utils.create_service_user(
         user=utils.CLOUDIFY_USER,
@@ -84,4 +74,3 @@ def init_cloudify_user():
 
 init_cloudify_user()
 configure_security_properties()
-create_certs()

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -118,4 +118,17 @@ def preconfigure_nginx():
     utils.systemd.enable(NGINX_SERVICE_NAME, append_prefix=False)
 
 
+def create_certs():
+    utils.mkdir(utils.SSL_CERTS_TARGET_DIR)
+    utils.generate_ca_cert()
+    networks = \
+        ctx.target.node.properties['cloudify']['cloudify_agent']['networks']
+    internal_rest_host = \
+        ctx.target.instance.runtime_properties['internal_rest_host']
+    utils.store_cert_metadata(internal_rest_host, networks)
+    cert_ips = [internal_rest_host] + list(networks.values())
+    utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
+
+
+create_certs()
 preconfigure_nginx()


### PR DESCRIPTION
Not all environments come with openssl preinstalled, and openssl is
only installed via nginx. Only after that can we create the certs.

For now, simply move the cert creation code to after openssl is
installed. In the future, let's install openssl explicitly and revert
this commit.