### PR TITLE
CFY-7200 IPSetter: update the default network in cert metadata

### DIFF
--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
         internal_rest_host = cert_metadata['internal_rest_host']
 
     networks = cert_metadata.get('networks', {})
+    networks['default'] = internal_rest_host
     cert_ips = [internal_rest_host] + list(networks.values())
     utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
-    utils.store_cert_metadata(internal_rest_host)
+    utils.store_cert_metadata(internal_rest_host, networks)


### PR DESCRIPTION
When the IP changes, we update the default network with the new ip
in the provider context. we also need to update the cert metadata
file as well.