### PR TITLE
CFY-7222 Sanity: fix mistyped call

### DIFF
--- a/components/sanity/scripts/start.py
+++ b/components/sanity/scripts/start.py
@@ -162,7 +162,7 @@ def _is_sanity_dep_exist(client):
 
 def _is_sanity_blueprint_exist(client):
     try:
-        client.deployments.get(BLUEPRINT_ID)
+        client.blueprints.get(BLUEPRINT_ID)
     except CloudifyClientError as e:
         if e.status_code != 404:
             raise


### PR DESCRIPTION
_is_sanity_blueprint_exist should of course check for blueprints,
not for deployments