### PR TITLE
CFY-7255 Scripts for manually editing manager networks

### DIFF
--- a/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
+++ b/components/manager-ip-setter/scripts/create-internal-ssl-certs.py
@@ -1,10 +1,9 @@
-
 # This script has to run using the Python executable found in:
 # /opt/mgmtworker/env/bin/python in order to properly load the manager
 # blueprints utils.py module.
 
+import argparse
 import logging
-import sys
 
 import utils
 
@@ -15,16 +14,22 @@ class CtxWithLogger(object):
 
 utils.ctx = CtxWithLogger()
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--metadata', default=utils.CERT_METADATA_FILE_PATH,
+                    help='File containing the cert metadata. It should be a '
+                         'JSON file containing an object with the '
+                         '"internal_rest_host" and "networks" fields.')
+parser.add_argument('manager_ip', default=None, nargs='?',
+                    help='The IP of this machine on the default network')
 
 if __name__ == '__main__':
-    cert_metadata = utils.load_cert_metadata()
-    if len(sys.argv) == 2:
-        internal_rest_host = sys.argv[1]
-    else:
-        internal_rest_host = cert_metadata['internal_rest_host']
+    args = parser.parse_args()
+    cert_metadata = utils.load_cert_metadata(filename=args.metadata)
+    internal_rest_host = args.manager_ip or cert_metadata['internal_rest_host']
 
     networks = cert_metadata.get('networks', {})
     networks['default'] = internal_rest_host
     cert_ips = [internal_rest_host] + list(networks.values())
     utils.generate_internal_ssl_cert(ips=cert_ips, name=internal_rest_host)
-    utils.store_cert_metadata(internal_rest_host, networks)
+    utils.store_cert_metadata(internal_rest_host, networks,
+                              filename=args.metadata)

--- a/components/utils.py
+++ b/components/utils.py
@@ -340,19 +340,20 @@ def _format_ips(ips):
     return cert_metadata
 
 
-def store_cert_metadata(internal_rest_host, networks=None):
+def store_cert_metadata(internal_rest_host, networks=None,
+                        filename=CERT_METADATA_FILE_PATH):
     metadata = load_cert_metadata()
     metadata['internal_rest_host'] = internal_rest_host
     if networks is not None:
         metadata['networks'] = networks
     contents = json.dumps(metadata)
-    sudo_write_to_file(contents, CERT_METADATA_FILE_PATH)
-    chown(CLOUDIFY_USER, CLOUDIFY_GROUP, CERT_METADATA_FILE_PATH)
+    sudo_write_to_file(contents, filename)
+    chown(CLOUDIFY_USER, CLOUDIFY_GROUP, filename)
 
 
-def load_cert_metadata():
+def load_cert_metadata(filename=CERT_METADATA_FILE_PATH):
     try:
-        with open(CERT_METADATA_FILE_PATH) as f:
+        with open(filename) as f:
             return json.load(f)
     except IOError:
         return {}


### PR DESCRIPTION
The IPSetter scripts can now be called manually to update the networks
used by the manager (in provider context, and the IPs stored in the cert).

Their interface is `script.py MANAGER_IP --networks FILENAME`, with the
default ip passed on the command line, and the file being a JSON file
containing a `{"networks": {"network_name": "1.2.3.4"}}` (identical to what
we called the  "cert metadata" file, and indeed the cert script defaults to
that location).