### PR TITLE
CFY-7240 Add authorization.conf path to environment variable

### DIFF
--- a/components/mgmtworker/config/cloudify-mgmtworker
+++ b/components/mgmtworker/config/cloudify-mgmtworker
@@ -11,6 +11,7 @@ LOCAL_REST_CERT_FILE="{{ ctx.instance.runtime_properties.local_rest_cert_file }}
 BROKER_SSL_CERT_PATH="{{ ctx.instance.runtime_properties.local_rest_cert_file }}"
 MANAGER_FILE_SERVER_URL="{{ ctx.instance.runtime_properties.file_server_url }}"
 MANAGER_FILE_SERVER_ROOT="{{ ctx.instance.runtime_properties.file_server_root }}"
+MANAGER_REST_AUTHORIZATION_CONFIG_PATH="{{ ctx.instance.runtime_properties.home_dir }}/authorization.conf"
 CELERY_TASK_SERIALIZER="json"
 CELERY_RESULT_SERIALIZER="json"
 CELERY_RESULT_BACKEND="amqp"


### PR DESCRIPTION
This will allow to set a different path for the `authorization.conf`
file if needed during bootstrap.