### PR TITLE
CFY-7236 Allow passing internal certs in inputs

### DIFF
--- a/components/nginx/scripts/create.py
+++ b/components/nginx/scripts/create.py
@@ -16,11 +16,16 @@ ctx_properties = ctx.node.properties.get_all()
 runtime_props = ctx.instance.runtime_properties
 runtime_props['service_name'] = SERVICE_NAME
 
+# those properties must be copied into runtime properties, for use in
+# the preconfigure script
+properties_to_copy = ['rest_key', 'rest_certificate', 'ca_cert', 'ca_key',
+                      'internal_cert', 'internal_key']
+
 LOG_DIR = join(utils.BASE_LOG_DIR, SERVICE_NAME)
 UNIT_OVERRIDE_PATH = '/etc/systemd/system/nginx.service.d'
 runtime_props['files_to_remove'] = [LOG_DIR, UNIT_OVERRIDE_PATH]
-runtime_props['rest_certificate'] = ctx_properties['rest_certificate']
-runtime_props['rest_key'] = ctx_properties['rest_key']
+for property_name in properties_to_copy:
+    runtime_props[property_name] = ctx_properties[property_name]
 
 CONFIG_PATH = 'components/{0}/config'.format(SERVICE_NAME)
 

--- a/components/nginx/scripts/create.py
+++ b/components/nginx/scripts/create.py
@@ -18,8 +18,8 @@ runtime_props['service_name'] = SERVICE_NAME
 
 # those properties must be copied into runtime properties, for use in
 # the preconfigure script
-properties_to_copy = ['rest_key', 'rest_certificate', 'ca_cert', 'ca_key',
-                      'internal_cert', 'internal_key']
+properties_to_copy = ['rest_key', 'rest_certificate', 'ca_certificate',
+                      'ca_key', 'internal_certificate', 'internal_key']
 
 LOG_DIR = join(utils.BASE_LOG_DIR, SERVICE_NAME)
 UNIT_OVERRIDE_PATH = '/etc/systemd/system/nginx.service.d'

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -83,6 +83,8 @@ def _deploy_nginx_config_files():
 
 def _deploy_cert_and_key(cert_src, key_src, cert_path, key_path):
     def _try_deploy(src, dest):
+        if not src:
+            return False
         try:
             utils.deploy_blueprint_resource(
                 src_runtime_props[src], dest, NGINX_SERVICE_NAME,

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -83,11 +83,12 @@ def _deploy_nginx_config_files():
 
 def _deploy_cert_and_key(cert_src, key_src, cert_path, key_path):
     def _try_deploy(src, dest):
-        if not src:
+        src_path = src_runtime_props[src]
+        if not src_path:
             return False
         try:
             utils.deploy_blueprint_resource(
-                src_runtime_props[src], dest, NGINX_SERVICE_NAME,
+                src_path, dest, NGINX_SERVICE_NAME,
                 user_resource=True, load_ctx=False)
             return True
         except Exception as e:

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -96,6 +96,17 @@ def _deploy_cert_and_key(cert_src, key_src, cert_path, key_path):
     return _try_deploy(cert_src, cert_path), _try_deploy(key_src, key_path)
 
 
+def _generate_external_cert():
+        utils.generate_ssl_certificate(
+            [target_runtime_props['external_rest_host'],
+             target_runtime_props['internal_rest_host']],
+            target_runtime_props['external_rest_host'],
+            utils.EXTERNAL_CERT_PATH,
+            utils.EXTERNAL_KEY_PATH,
+            sign_cert=None, sign_key=None
+        )
+
+
 def _deploy_external_cert():
     external_cert_deployed, external_key_deployed = _deploy_cert_and_key(
         'rest_certificate', 'rest_key',
@@ -105,14 +116,7 @@ def _deploy_external_cert():
         ctx.logger.info(
             'Deployed user-provided external SSL certificate and private key')
     elif not external_cert_deployed and not external_key_deployed:
-        utils.generate_ssl_certificate(
-            [target_runtime_props['external_rest_host'],
-             target_runtime_props['internal_rest_host']],
-            target_runtime_props['external_rest_host'],
-            utils.EXTERNAL_CERT_PATH,
-            utils.EXTERNAL_KEY_PATH,
-            sign_cert=None, sign_key=None
-        )
+        _generate_external_cert()
     else:
         what_deployed = 'cert' if external_cert_deployed else 'key'
         ctx.abort_operation('Either both the external cert and the external '

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -97,13 +97,19 @@ def preconfigure_nginx():
     # Pass on the the path to the certificate to manager_configuration
     target_runtime_props['internal_cert_path'] = utils.INTERNAL_CA_CERT_PATH
 
-    utils.deploy_or_generate_external_ssl_cert(
-        [target_runtime_props['external_rest_host'],
-         target_runtime_props['internal_rest_host']],
-        target_runtime_props['external_rest_host'],
-        src_runtime_props['rest_certificate'],
-        src_runtime_props['rest_key']
-    )
+    if not utils.deploy_ssl_cert(
+            src_runtime_props['rest_certificate'],
+            src_runtime_props['rest_key'],
+            utils.EXTERNAL_CERT_PATH,
+            utils.EXTERNAL_KEY_PATH):
+        utils.generate_ssl_certificate(
+            [target_runtime_props['external_rest_host'],
+             target_runtime_props['internal_rest_host']],
+            target_runtime_props['external_rest_host'],
+            utils.EXTERNAL_CERT_PATH,
+            utils.EXTERNAL_KEY_PATH,
+            sign_cert=None, sign_key=None
+        )
 
     src_runtime_props['external_cert_path'] = utils.EXTERNAL_CERT_PATH
     src_runtime_props['external_key_path'] = utils.EXTERNAL_KEY_PATH

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -12,6 +12,7 @@ ctx.download_resource(
 import utils  # NOQA
 
 src_runtime_props = ctx.source.instance.runtime_properties
+target_runtime_props = ctx.target.instance.runtime_properties
 NGINX_SERVICE_NAME = src_runtime_props['service_name']
 CONFIG_PATH = 'components/{0}/config'.format(NGINX_SERVICE_NAME)
 
@@ -96,8 +97,6 @@ def _deploy_cert_and_key(cert_src, key_src, cert_path, key_path):
 
 
 def _deploy_external_cert():
-    target_runtime_props = ctx.target.instance.runtime_properties
-
     external_cert_deployed, external_key_deployed = _deploy_cert_and_key(
         'rest_certificate', 'rest_key',
         utils.EXTERNAL_CERT_PATH, utils.EXTERNAL_KEY_PATH)
@@ -126,8 +125,6 @@ def _deploy_external_cert():
 
 def preconfigure_nginx():
     # This is used by nginx's default.conf to select the relevant configuration
-    target_runtime_props = ctx.target.instance.runtime_properties
-
     external_rest_protocol = target_runtime_props['external_rest_protocol']
     internal_rest_port = target_runtime_props['internal_rest_port']
 

--- a/components/nginx/scripts/preconfigure.py
+++ b/components/nginx/scripts/preconfigure.py
@@ -152,7 +152,7 @@ def preconfigure_nginx():
 def create_certs():
     utils.mkdir(utils.SSL_CERTS_TARGET_DIR)
     ca_cert_deployed, ca_key_deployed = _deploy_cert_and_key(
-        'ca_cert', 'ca_key',
+        'ca_certificate', 'ca_key',
         utils.INTERNAL_CA_CERT_PATH, utils.INTERNAL_CA_KEY_PATH)
     has_ca_key = ca_key_deployed
     if not ca_cert_deployed:
@@ -169,7 +169,7 @@ def create_certs():
     utils.store_cert_metadata(internal_rest_host, networks)
 
     internal_cert_deployed, internal_key_deployed = _deploy_cert_and_key(
-        'internal_cert', 'internal_key',
+        'internal_certificate', 'internal_key',
         utils.INTERNAL_CERT_PATH, utils.INTERNAL_KEY_PATH)
 
     if not internal_cert_deployed and not internal_key_deployed:

--- a/components/utils.py
+++ b/components/utils.py
@@ -462,33 +462,6 @@ def generate_internal_ssl_cert(ips, name):
     )
 
 
-def deploy_ssl_cert(cert_source, key_source, cert_path, key_path):
-    cert_filename = os.path.basename(cert_path)
-    key_filename = os.path.basename(key_path)
-    try:
-        # Try to deploy user provided certificates
-        deploy_blueprint_resource(cert_source,
-                                  cert_path,
-                                  NGINX_SERVICE_NAME,
-                                  user_resource=True,
-                                  load_ctx=False)
-        deploy_blueprint_resource(key_source,
-                                  key_path,
-                                  NGINX_SERVICE_NAME,
-                                  user_resource=True,
-                                  load_ctx=False)
-        ctx.logger.info(
-            'Deployed user-provided SSL certificate `{0}` and SSL private '
-            'key `{1}`'.format(cert_filename, key_filename)
-        )
-        return True
-    except Exception as e:
-        if "No such file or directory" in e.stderr:
-            return False
-        else:
-            raise
-
-
 def write_to_tempfile(contents):
     fd, file_path = tempfile.mkstemp()
     os.write(fd, contents)

--- a/components/utils.py
+++ b/components/utils.py
@@ -1306,7 +1306,7 @@ class BlueprintResourceFactory(object):
         node_props = ctx.node.properties.get_all()
         return {'node': {'properties': node_props}}
 
-    def _is_cloudify_pkg(self,  filename):
+    def _is_cloudify_pkg(self, filename):
         """Cloudify packages start with 'cloudify' or include '-agent_'
 
         and end with one of the suffix '.rpm', '.tar.gz', '.tgz', '.exe'.
@@ -1314,8 +1314,8 @@ class BlueprintResourceFactory(object):
         packages except of single tar package.
         """
 
-        if (filename.startswith('cloudify')
-            or filename.find('-agent_') != -1) \
+        if (filename.startswith('cloudify') or
+            filename.find('-agent_') != -1) \
                 and not filename.startswith(SINGLE_TAR_PREFIX) \
                 and filename.endswith(('.rpm', '.tar.gz', '.tgz', '.exe')):
             return True

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -21,18 +21,22 @@ inputs:
   ca_certificate:
     description: Internal CA certificate
     type: string
+    default: ''
 
   ca_key:
     description: Private key for the internal CA certificate
     type: string
+    default: ''
 
   internal_certificate:
     description: Internal certificate
     type: string
+    default: ''
 
   internal_key:
     description: Private key for the internal certificate
     type: string
+    default: ''
 
   admin_username:
     default: admin

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -18,7 +18,7 @@ inputs:
     type: string
     default: resources/ssl/cloudify_external_key.pem
 
-  ca_cert:
+  ca_certificate:
     description: Internal CA certificate
     type: string
 
@@ -26,7 +26,7 @@ inputs:
     description: Private key for the internal CA certificate
     type: string
 
-  internal_cert:
+  internal_certificate:
     description: Internal certificate
     type: string
 

--- a/inputs/manager-inputs.yaml
+++ b/inputs/manager-inputs.yaml
@@ -18,6 +18,22 @@ inputs:
     type: string
     default: resources/ssl/cloudify_external_key.pem
 
+  ca_cert:
+    description: Internal CA certificate
+    type: string
+
+  ca_key:
+    description: Private key for the internal CA certificate
+    type: string
+
+  internal_cert:
+    description: Internal certificate
+    type: string
+
+  internal_key:
+    description: Private key for the internal certificate
+    type: string
+
   admin_username:
     default: admin
 

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -503,18 +503,18 @@ node_types:
         description: Private key for rest ssl certificate
         type: string
         default: { get_input: rest_key }
-      ca_cert:
+      ca_certificate:
         description: Internal CA certificate
         type: string
-        default: { get_input: ca_cert }
+        default: { get_input: ca_certificate }
       ca_key:
         description: Private key for the internal CA certificate
         type: string
         default: { get_input: ca_key }
-      internal_cert:
+      internal_certificate:
         description: Internal certificate
         type: string
-        default: { get_input: internal_cert }
+        default: { get_input: internal_certificate }
       internal_key:
         description: Private key for the internal certificate
         type: string

--- a/types/manager-types.yaml
+++ b/types/manager-types.yaml
@@ -503,6 +503,22 @@ node_types:
         description: Private key for rest ssl certificate
         type: string
         default: { get_input: rest_key }
+      ca_cert:
+        description: Internal CA certificate
+        type: string
+        default: { get_input: ca_cert }
+      ca_key:
+        description: Private key for the internal CA certificate
+        type: string
+        default: { get_input: ca_key }
+      internal_cert:
+        description: Internal certificate
+        type: string
+        default: { get_input: internal_cert }
+      internal_key:
+        description: Private key for the internal certificate
+        type: string
+        default: { get_input: internal_key }
       nginx_rpm_source_url:
         description: Nginx RPM Source URL
         type: string


### PR DESCRIPTION
This adds the inputs `ca_certificate`, `ca_key`, `internal_certificate` and `internal_key`.

The user can now pass the internal CA cert+key, and the internal cert+key.

Optionally, the user can choose to not provide the CA key, but only the cert.
In this case, it is required that the user also provides the internal cert+key,
because they can't be generated without a CA key.

This means it is now possible to generate all the required certificates before
bootstrapping a manager, and cloudify does not require the CA key that was
used to generate the keys.