### PR TITLE
CFY-7373 Add tenant_update_group action

### DIFF
--- a/components/restservice/config/authorization.conf
+++ b/components/restservice/config/authorization.conf
@@ -334,6 +334,9 @@ permissions:
   tenant_add_group:
     - sys_admin
     - manager
+  tenant_update_group:
+    - sys_admin
+    - manager
   tenant_remove_group:
     - sys_admin
     - manager


### PR DESCRIPTION
This action is used to update the group-tenant relationship. For now,
that means updating the role.