### PR TITLE
CFY-7423: fix order of RPM installation

### DIFF
--- a/components/python/scripts/create.py
+++ b/components/python/scripts/create.py
@@ -26,10 +26,10 @@ def install_python_requirements():
     utils.set_selinux_permissive()
     utils.copy_notice('python')
 
-    for rpm in [pip_source_rpm_url,
-                python_backports_rpm_url,
+    for rpm in [python_backports_rpm_url,
                 python_backports_ssl_match_hostname_rpm_url,
-                python_setuptools_rpm_url]:
+                python_setuptools_rpm_url,
+                pip_source_rpm_url]:
         utils.yum_install(rpm, service_name='python')
 
     if install_python_compilers:


### PR DESCRIPTION
Backports & setuptools are prerequisites for pip.