### PR TITLE
CFY-7485 Drop Stage and Composer tables before trying to drop the user

### DIFF
--- a/components/postgresql/config/create_default_db.sh
+++ b/components/postgresql/config/create_default_db.sh
@@ -24,6 +24,8 @@ function clean_database_and_user() {
     db_name=$1
     user=$2
     run_psql "DROP DATABASE IF EXISTS $db_name;"
+    run_psql "DROP DATABASE IF EXISTS $stage_db_name;"
+    run_psql "DROP DATABASE IF EXISTS $composer_db_name;"
     run_psql "DROP USER IF EXISTS $user;"
 }
 


### PR DESCRIPTION
In cases where trying several times to bootstrap the manager, this will
fix the problem of trying to drop a user that has tables associated with
him